### PR TITLE
[BUG] Correct the pom for shuffle-manager-2 for include com.aliyun.emr:client

### DIFF
--- a/client-spark/shuffle-manager-2/pom.xml
+++ b/client-spark/shuffle-manager-2/pom.xml
@@ -124,7 +124,7 @@
                                     <!-- Include here the dependencies you
                                         want to be packed in your fat jar -->
                                     <include>com.aliyun.emr:common</include>
-                                    <include>com.aliyun.emr:client-java</include>
+                                    <include>com.aliyun.emr:client</include>
                                     <include>com.aliyun.emr:shuffle-manager-common</include>
                                     <include>com.aliyun.emr:shuffle-manager</include>
                                 </includes>


### PR DESCRIPTION
[BUG] Correct the pom for shuffle-manager-2 for include com.aliyun.emr:client

### What changes were proposed in this pull request?
Update the shuffle-manager-2 for include com.aliyun.emr:client-java to com.aliyun.emr:client

### Why are the changes needed?
Without this fix, shuffle-manager-2 will throw ClassNotForndException

### What are the items that need reviewer attention?
N/A

### Related issues.
#23 

### Related pull requests.
N/A

### How was this patch tested?
./dev/make-distribution.sh -Pspark-2 -Dspark.version=2.4.5
grep -lr "ShuffleClient" ${package}/spark/*

/cc @waitinfuture @FMX 

/assign @wangshengjie123
