### PR TITLE
[ISSUE-80] When rss is in blacklist and failed for reserve, rpcRef could be null

### DIFF
--- a/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/java/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -800,9 +800,11 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
           })
         }
         // remove failed slot from total slots, close transport client
-        val transportClient = workerInfo.endpoint.asInstanceOf[NettyRpcEndpointRef].client
-        if (null != transportClient && transportClient.isActive) {
-          transportClient.close()
+        if (workerInfo.endpoint != null) {
+          val transportClient = workerInfo.endpoint.asInstanceOf[NettyRpcEndpointRef].client
+          if (null != transportClient && transportClient.isActive) {
+            transportClient.close()
+          }
         }
       })
 
@@ -1022,7 +1024,7 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
   private def handleGetBlacklist(msg: GetBlacklist): Unit = {
     val res = requestGetBlacklist(rssHARetryClient, msg)
     if (res.statusCode == StatusCode.Success) {
-      logInfo(s"Received Blacklist from Master, blacklist: ${res.blacklist}" +
+      logInfo(s"Received Blacklist from Master, blacklist: ${res.blacklist} " +
         s"unkown workers: ${res.unknownWorkers}")
       blacklist.clear()
       if (res.blacklist != null) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When testing close and restart a worker when  running application

Worker in blacklist and WorkerRef is null
```
22/03/29 15:01:46 WARN LifecycleManager: [reserve buffer] failed due to blacklist:
Host: xxx.xxx.xxx.xx
RpcPort: 45149
PushPort: 46795
FetchPort: 38947
TotalSlots: -1
SlotsUsed: 0
SlotsAvailable: -1
LastHeartBeat: 0
WorkerRef: null

```

Cause task throw NPE when reserveSlot 
```

22/03/29 15:01:46 ERROR Inbox: Ignoring error
java.lang.NullPointerException
	at com.aliyun.emr.rss.client.write.LifecycleManager.$anonfun$reserveSlotsWithRetry$2(LifecycleManager.scala:803)
	at com.aliyun.emr.rss.client.write.LifecycleManager.$anonfun$reserveSlotsWithRetry$2$adapted(LifecycleManager.scala:787)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at scala.collection.IterableLike.foreach(IterableLike.scala:74)
	at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
	at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
	at com.aliyun.emr.rss.client.write.LifecycleManager.reserveSlotsWithRetry(LifecycleManager.scala:787)
	at com.aliyun.emr.rss.client.write.LifecycleManager.handleRegisterShuffle(LifecycleManager.scala:287)
	at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:180)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)


```


### Why are the changes needed?
this error will cause job failed when rolling restart, we should fix thsi,

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
