### PR TITLE
[BUG] Register shuffle with configurable retry times and retry wait time

### DIFF
--- a/CONFIGURATION_GUIDE.md
+++ b/CONFIGURATION_GUIDE.md
@@ -147,6 +147,7 @@ So we should set `rss.worker.flush.queue.capacity=6553` and each RSS worker has 
 | `rss.worker.numSlots` | -1 | int | |
 | `rss.rpc.max.parallelism` | 1024 | int | |
 | `rss.register.shuffle.max.retry` | 3 | int | |
+| `rss.register.shuffle.retry.wait` | 3000 | int | |
 | `rss.flush.timeout` | 240 s | String | |
 | `rss.expire.nonEmptyDir.duration` | 3 d | String | |
 | `rss.expire.nonEmptyDir.cleanUp.threshold` | 10 | int | |

--- a/CONFIGURATION_GUIDE.md
+++ b/CONFIGURATION_GUIDE.md
@@ -147,7 +147,7 @@ So we should set `rss.worker.flush.queue.capacity=6553` and each RSS worker has 
 | `rss.worker.numSlots` | -1 | int | |
 | `rss.rpc.max.parallelism` | 1024 | int | |
 | `rss.register.shuffle.max.retry` | 3 | int | |
-| `rss.register.shuffle.retry.wait` | 3000 | int | |
+| `rss.register.shuffle.retry.wait` | 3s | int | |
 | `rss.flush.timeout` | 240 s | String | |
 | `rss.expire.nonEmptyDir.duration` | 3 d | String | |
 | `rss.expire.nonEmptyDir.cleanUp.threshold` | 10 | int | |

--- a/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
@@ -86,7 +86,7 @@ public class ShuffleClientImpl extends ShuffleClient {
 
   private final RssConf conf;
   private final int registerShuffleMaxRetries;
-  private final int registerShuffleRetryWait;
+  private final long registerShuffleRetryWait;
   private final int maxInFlight;
   private final int pushBufferSize;
 

--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -508,6 +508,10 @@ object RssConf extends Logging {
     conf.getInt("rss.register.shuffle.max.retry", 3)
   }
 
+  def registerShuffleRetryWait(conf: RssConf): Int = {
+    conf.getInt("rss.register.shuffle.retry.wait", 3000)
+  }
+
   def flushTimeout(conf: RssConf): Long = {
     conf.getTimeAsSeconds("rss.flush.timeout", "120s")
   }

--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -508,8 +508,8 @@ object RssConf extends Logging {
     conf.getInt("rss.register.shuffle.max.retry", 3)
   }
 
-  def registerShuffleRetryWait(conf: RssConf): Int = {
-    conf.getInt("rss.register.shuffle.retry.wait", 3000)
+  def registerShuffleRetryWait(conf: RssConf): Long = {
+    conf.getTimeAsSeconds("rss.register.shuffle.retry.wait", "3s")
   }
 
   def flushTimeout(conf: RssConf): Long = {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When test RSS I noticed that register shuffle failed too quickly and seems not retry, after read the code found that the retry times and retry wait time can't be customized and the original retry wait is 3ms, seems. wrong.

### Why are the changes needed?



### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
