### PR TITLE
[Feature] update netty and ratis version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <codahale.metrics.version>3.2.6</codahale.metrics.version>
     <javaxservlet.version>3.1.0</javaxservlet.version>
     <!-- Apache Ratis version -->
-    <ratis.version>2.0.0</ratis.version>
+    <ratis.version>2.2.0</ratis.version>
     <!-- ProtocolBuffer version, used to verify the protoc version and -->
     <!-- define the protobuf JAR version                               -->
     <protobuf.version>3.5.1</protobuf.version><!-- Maven protoc compiler -->
@@ -162,7 +162,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
-        <version>4.1.73.Final</version>
+        <version>4.1.77.Final</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>

--- a/server-master/src/test/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
+++ b/server-master/src/test/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/MasterStateMachineSuiteJ.java
@@ -76,7 +76,7 @@ public class MasterStateMachineSuiteJ extends RatisBaseSuiteJ {
 
     File storageDir = Utils.createTempDir("./", "snapshot");
 
-    final RaftStorage storage = new RaftStorageImpl(storageDir, null);
+    final RaftStorage storage = new RaftStorageImpl(storageDir, null, 100);
     SimpleStateMachineStorage simpleStateMachineStorage =
       (SimpleStateMachineStorage)stateMachine.getStateMachineStorage();
     simpleStateMachineStorage.init(storage);


### PR DESCRIPTION
# [Feature] update netty and ratis version.

### What changes were proposed in this pull request?
For improved performance and bugfix.
There are some changes in memory.
https://netty.io/news/2022/03/10/4-1-75-Final.html

Netty 4.1.77
ratis 2.2.0
<img width="1177" alt="截屏2022-05-19 10 00 18" src="https://user-images.githubusercontent.com/4150993/169187748-e6b79bee-968d-4d7b-97dc-6167a4387cf0.png">
<img width="1126" alt="截屏2022-05-19 10 03 48" src="https://user-images.githubusercontent.com/4150993/169188049-41b46fc3-2ab9-4a3c-9a9f-4d2536476268.png">



Betty 4.1.73
ratis 2.0.0

<img width="1176" alt="截屏2022-05-19 10 01 01" src="https://user-images.githubusercontent.com/4150993/169187785-d81297dc-413d-4ae3-96e2-7b963c5bed6e.png">
 
<img width="1129" alt="截屏2022-05-19 10 05 19" src="https://user-images.githubusercontent.com/4150993/169188205-8de6778e-8649-4d88-861b-15c9bf075c8a.png">


### Why are the changes needed?


### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
