### PR TITLE
[FEATURE]Add metrics source for JVM and CPU

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -58,6 +58,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-jvm</artifactId>
+      <version>${codahale.metrics.version}</version>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMCPUSource.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMCPUSource.scala
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.aliyun.emr.rss.common.metrics.source
 
 import java.lang.management.ManagementFactory
@@ -5,10 +22,12 @@ import javax.management.{MBeanServer, ObjectName}
 
 import scala.util.control.NonFatal
 
-import com.aliyun.emr.rss.common.RssConf
 import com.codahale.metrics.Gauge
 
-class JVMCPUSource(rssConf: RssConf, role: String) extends AbstractSource(rssConf: RssConf, role: String) {
+import com.aliyun.emr.rss.common.RssConf
+
+class JVMCPUSource(rssConf: RssConf, role: String)
+  extends AbstractSource(rssConf: RssConf, role: String) {
   override val sourceName = "CPU"
 
   import JVMCPUSource._

--- a/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMCPUSource.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMCPUSource.scala
@@ -1,0 +1,35 @@
+package com.aliyun.emr.rss.common.metrics.source
+
+import java.lang.management.ManagementFactory
+import javax.management.{MBeanServer, ObjectName}
+
+import scala.util.control.NonFatal
+
+import com.aliyun.emr.rss.common.RssConf
+import com.codahale.metrics.Gauge
+
+class JVMCPUSource(rssConf: RssConf, role: String) extends AbstractSource(rssConf: RssConf, role: String) {
+  override val sourceName = "CPU"
+
+  import JVMCPUSource._
+
+  addGauge(JVMCPUTime, new Gauge[Long] {
+    val mBean: MBeanServer = ManagementFactory.getPlatformMBeanServer
+    val name = new ObjectName("java.lang", "type", "OperatingSystem")
+
+    override def getValue: Long = {
+      try {
+        // return JVM process CPU time if the ProcessCpuTime method is available
+        mBean.getAttribute(name, "ProcessCpuTime").asInstanceOf[Long]
+      } catch {
+        case NonFatal(_) => -1L
+      }
+    }
+  })
+  // start cleaner
+  startCleaner()
+}
+
+object JVMCPUSource {
+  val JVMCPUTime = "JVMCPUTime"
+}

--- a/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMSource.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMSource.scala
@@ -1,14 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.aliyun.emr.rss.common.metrics.source
 
 import java.lang.management.ManagementFactory
 
 import scala.collection.JavaConverters._
 
-import com.aliyun.emr.rss.common.RssConf
 import com.codahale.metrics.Gauge
 import com.codahale.metrics.jvm.{BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet}
 
-class JVMSource(rssConf: RssConf, role: String) extends AbstractSource(rssConf: RssConf, role: String) {
+import com.aliyun.emr.rss.common.RssConf
+
+class JVMSource(rssConf: RssConf, role: String)
+  extends AbstractSource(rssConf: RssConf, role: String) {
   override val sourceName = "JVM"
 
   // all of metrics of GCMetricSet and BufferPoolMetricSet are Gauge

--- a/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMSource.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/metrics/source/JVMSource.scala
@@ -1,0 +1,24 @@
+package com.aliyun.emr.rss.common.metrics.source
+
+import java.lang.management.ManagementFactory
+
+import scala.collection.JavaConverters._
+
+import com.aliyun.emr.rss.common.RssConf
+import com.codahale.metrics.Gauge
+import com.codahale.metrics.jvm.{BufferPoolMetricSet, GarbageCollectorMetricSet, MemoryUsageGaugeSet}
+
+class JVMSource(rssConf: RssConf, role: String) extends AbstractSource(rssConf: RssConf, role: String) {
+  override val sourceName = "JVM"
+
+  // all of metrics of GCMetricSet and BufferPoolMetricSet are Gauge
+  Seq(new GarbageCollectorMetricSet(),
+    new MemoryUsageGaugeSet(),
+    new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer))
+    .map { x => x.getMetrics.asScala.map {
+      case (name: String, metric: Gauge[_]) => addGauge(name, metric)
+    }
+    }
+  // start cleaner
+  startCleaner()
+}

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -30,6 +30,7 @@ import com.aliyun.emr.rss.common.haclient.RssHARetryClient
 import com.aliyun.emr.rss.common.internal.Logging
 import com.aliyun.emr.rss.common.meta.WorkerInfo
 import com.aliyun.emr.rss.common.metrics.MetricsSystem
+import com.aliyun.emr.rss.common.metrics.source.{JVMCPUSource, JVMSource}
 import com.aliyun.emr.rss.common.protocol.{PartitionLocation, RpcNameConstants}
 import com.aliyun.emr.rss.common.protocol.message.ControlMessages._
 import com.aliyun.emr.rss.common.protocol.message.StatusCode
@@ -41,10 +42,10 @@ import com.aliyun.emr.rss.service.deploy.master.clustermeta.ha.{HAHelper, HAMast
 import com.aliyun.emr.rss.service.deploy.master.http.HttpRequestHandler
 
 private[deploy] class Master(
-                              override val rpcEnv: RpcEnv,
-                              address: RpcAddress,
-                              val conf: RssConf,
-                              val metricsSystem: MetricsSystem)
+    override val rpcEnv: RpcEnv,
+    address: RpcAddress,
+    val conf: RssConf,
+    val metricsSystem: MetricsSystem)
   extends RpcEndpoint with Logging {
 
   private val statusSystem = if (haEnabled(conf)) {
@@ -97,6 +98,8 @@ private[deploy] class Master(
       })
 
     metricsSystem.registerSource(source)
+    metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_MASTER))
+    metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_MASTER))
     source
   }
 

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
@@ -39,7 +39,7 @@ import com.aliyun.emr.rss.common.haclient.RssHARetryClient
 import com.aliyun.emr.rss.common.internal.Logging
 import com.aliyun.emr.rss.common.meta.{PartitionLocationInfo, WorkerInfo}
 import com.aliyun.emr.rss.common.metrics.MetricsSystem
-import com.aliyun.emr.rss.common.metrics.source.NetWorkSource
+import com.aliyun.emr.rss.common.metrics.source.{JVMCPUSource, JVMSource, NetWorkSource}
 import com.aliyun.emr.rss.common.network.TransportContext
 import com.aliyun.emr.rss.common.network.buffer.NettyManagedBuffer
 import com.aliyun.emr.rss.common.network.client.{RpcResponseCallback, TransportClientBootstrap}
@@ -55,15 +55,17 @@ import com.aliyun.emr.rss.server.common.http.{HttpServer, HttpServerInitializer}
 import com.aliyun.emr.rss.service.deploy.worker.http.HttpRequestHandler
 
 private[deploy] class Worker(
-                              override val rpcEnv: RpcEnv,
-                              val conf: RssConf,
-                              val metricsSystem: MetricsSystem)
+    override val rpcEnv: RpcEnv,
+    val conf: RssConf,
+    val metricsSystem: MetricsSystem)
   extends RpcEndpoint with PushDataHandler with OpenStreamHandler with Registerable with Logging {
 
   private val workerSource = {
     val source = new WorkerSource(conf)
     metricsSystem.registerSource(source)
     metricsSystem.registerSource(new NetWorkSource(conf, MetricsSystem.ROLE_WOKRER))
+    metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_WOKRER))
+    metricsSystem.registerSource(new JVMCPUSource(conf, MetricsSystem.ROLE_WOKRER))
     source
   }
 


### PR DESCRIPTION
# [FEATURE]Add metrics source for JVM and CPU 

### What changes were proposed in this pull request?
Add metric source for JVM and JVMCPU, register on master and work for performance monitor.

### Why are the changes needed?
Help to monitor the JVM performance of master and worker, if cluster has a large number of new users/shuffles we can better judge whether current cluster situation can support them.

### What are the items that need reviewer attention?
name format of new added metrics under JVMSource is different with previous Source's metrics, because it directly use MetricSet under com.codahale.metrics.jvm to register. 
New added metrics example:
(JVMSource metrics)
metrics_PS_Scavenge_count_Value{role="Worker"} 1 1653560687351
metrics_PS_Scavenge_time_Value{role="Worker"} 121 1653560687351
metrics_PS_MarkSweep_count_Value{role="Worker"} 1 1653560687351
metrics_PS_MarkSweep_time_Value{role="Worker"} 140 1653560687351
metrics_heap_committed_Value{role="Worker"} 1488453632 1653560687351
metrics_non_heap_used_Value{role="Worker"} 36405984 1653560687351
metrics_pools_Code_Cache_used_Value{role="Worker"} 8808000 1653560687351
metrics_pools_Code_Cache_committed_Value{role="Worker"} 9043968 1653560687351
metrics_heap_used_Value{role="Worker"} 261853960 1653560687351
metrics_pools_PS_Old_Gen_init_Value{role="Worker"} 1431830528 1653560687351
metrics_total_committed_Value{role="Worker"} 1526333440 1653560687351
metrics_pools_PS_Old_Gen_max_Value{role="Worker"} 14316732416 1653560687351
metrics_total_init_Value{role="Worker"} 2150039552 1653560687351
metrics_non_heap_max_Value{role="Worker"} -1 1653560687351
metrics_pools_PS_Eden_Space_init_Value{role="Worker"} 537395200 1653560687351
metrics_pools_Compressed_Class_Space_used_Value{role="Worker"} 3204904 1653560687351
metrics_pools_Metaspace_usage_Value{role="Worker"} 0.9593011915069265 1653560687351
metrics_pools_Metaspace_max_Value{role="Worker"} -1 1653560687351
metrics_pools_PS_Survivor_Space_used_after_gc_Value{role="Worker"} 0 1653560687351
metrics_pools_PS_Eden_Space_committed_Value{role="Worker"} 537395200 1653560687351
metrics_pools_PS_Eden_Space_max_Value{role="Worker"} 6979846144 1653560687351
metrics_pools_Compressed_Class_Space_usage_Value{role="Worker"} 0.0029847994446754456 1653560687351
metrics_heap_usage_Value{role="Worker"} 0.013717673998257 1653560687351
metrics_pools_PS_Eden_Space_usage_Value{role="Worker"} 0.031162238753209972 1653560687351
metrics_pools_PS_Survivor_Space_max_Value{role="Worker"} 89128960 1653560687351
metrics_pools_Code_Cache_max_Value{role="Worker"} 251658240 1653560687351
metrics_pools_Compressed_Class_Space_init_Value{role="Worker"} 0 1653560687351
metrics_pools_Metaspace_init_Value{role="Worker"} 0 1653560687351
metrics_pools_PS_Survivor_Space_usage_Value{role="Worker"} 0.0 1653560687351
metrics_pools_PS_Old_Gen_usage_Value{role="Worker"} 0.0030975174160857905 1653560687351
metrics_pools_Code_Cache_usage_Value{role="Worker"} 0.034999847412109375 1653560687351
metrics_pools_PS_Survivor_Space_init_Value{role="Worker"} 89128960 1653560687351
metrics_pools_PS_Old_Gen_used_after_gc_Value{role="Worker"} 44346328 1653560687351
metrics_total_used_Value{role="Worker"} 298259944 1653560687351
metrics_pools_Code_Cache_init_Value{role="Worker"} 2555904 1653560687351
metrics_pools_PS_Old_Gen_committed_Value{role="Worker"} 861929472 1653560687351
metrics_heap_init_Value{role="Worker"} 2147483648 1653560687351
metrics_non_heap_committed_Value{role="Worker"} 37879808 1653560687351
metrics_pools_Compressed_Class_Space_committed_Value{role="Worker"} 3407872 1653560687351
metrics_non_heap_init_Value{role="Worker"} 2555904 1653560687351
metrics_pools_PS_Eden_Space_used_Value{role="Worker"} 217507632 1653560687351
metrics_pools_PS_Eden_Space_used_after_gc_Value{role="Worker"} 0 1653560687351
metrics_non_heap_usage_Value{role="Worker"} -3.6405984E7 1653560687351
metrics_heap_max_Value{role="Worker"} 19088801792 1653560687351
metrics_pools_PS_Survivor_Space_used_Value{role="Worker"} 0 1653560687351
metrics_pools_Metaspace_committed_Value{role="Worker"} 25427968 1653560687351
metrics_total_max_Value{role="Worker"} 19088801791 1653560687351
metrics_pools_Metaspace_used_Value{role="Worker"} 24393080 1653560687351
metrics_pools_Compressed_Class_Space_max_Value{role="Worker"} 1073741824 1653560687351
metrics_pools_PS_Survivor_Space_committed_Value{role="Worker"} 89128960 1653560687351
metrics_pools_PS_Old_Gen_used_Value{role="Worker"} 44346328 1653560687351
metrics_direct_count_Value{role="Worker"} 6 1653560687351
metrics_mapped_used_Value{role="Worker"} 0 1653560687351
metrics_mapped_capacity_Value{role="Worker"} 0 1653560687351
metrics_direct_capacity_Value{role="Worker"} 1073 1653560687351
metrics_direct_used_Value{role="Worker"} 1074 1653560687351
metrics_mapped_count_Value{role="Worker"} 0 1653560687351
(JVMCPUSource)
metrics_JVMCPUTime_Value{role="Worker"} 13900000000 1653560687352

### Related issues.
https://github.com/alibaba/RemoteShuffleService/issues/124
### Related pull requests.

### How was this patch tested?
unit test