### PR TITLE
[ISSUE-148][BUG] MapEnd but speculation task's inFlightBatch not cleaned

### DIFF
--- a/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/ShuffleClientImpl.java
@@ -506,16 +506,17 @@ public class ShuffleClientImpl extends ShuffleClient {
                 mapId, attemptId, nextBatchId);
               splitPartition(shuffleId, reduceId, applicationId, loc);
               callback.onSuccess(response);
-            }
-            if (reason == StatusCode.HardSplit.getValue()) {
+            } else if (reason == StatusCode.HardSplit.getValue()) {
               logger.debug("Push data split for map {} attempt {} batch {}.",
                 mapId, attemptId, nextBatchId);
               pushDataRetryPool.submit(() -> submitRetryPushData(applicationId, shuffleId, mapId,
                 attemptId, body, nextBatchId, loc, this, pushState,
                 StatusCode.HardSplit));
+            } else {
+              response.rewind();
+              callback.onSuccess(response);
             }
           } else {
-            response.rewind();
             callback.onSuccess(response);
           }
         }


### PR DESCRIPTION
# [BUG]/[FEATURE] MapEnd but speculation task's inFlightBatch not cleaned

### What changes were proposed in this pull request?
Fix bug about success response replied by inFlightBatch not clean the corresponding batch. Finally stage failed caused by check inFlighBatchs

### Why are the changes needed?
Fix Bug

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
