### PR TITLE
[ISSUE-158][BUG] When revive meet reserve slot filed, will throw ArrayBoundOutOfIndex exception

### DIFF
--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -897,6 +897,10 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
                 slavePartitionLocations.remove(partition)
                 destroyResource.computeIfAbsent(workerInfoWithRpcRef, newMapFunc)._2.add(partition)
               }
+              if (slots.containsKey(workerInfoWithRpcRef) && masterPartitionLocations.isEmpty &&
+                slavePartitionLocations.isEmpty) {
+                slots.remove(workerInfoWithRpcRef)
+              }
             }
           })
           if (!destroyResource.isEmpty) {

--- a/server-worker/pom.xml
+++ b/server-worker/pom.xml
@@ -46,6 +46,23 @@
         </dependency>
 
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+            <version>4.1.77.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+            <version>4.1.77.Final</version>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.8.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/server-worker/pom.xml
+++ b/server-worker/pom.xml
@@ -46,23 +46,6 @@
         </dependency>
 
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-            <version>4.1.77.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-buffer</artifactId>
-            <version>4.1.77.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
### What changes were proposed in this pull request?
In current code, handRevive will throw below exception
```
22/06/23 02:21:15 ERROR LifecycleManager: [reserveSlots] Failed to reserve buffers for application_1655794079700_241721_1-1 from worker Host:10.169.21.29:RpcPort:28295:PushPort:21395:FetchPort:26315:ReplicatePort:32247. Reason: Exception when askSync Res
erveSlots for application_1655794079700_241721_1-1, Exception thrown in awaitResult:
22/06/23 02:21:15 ERROR Inbox: Ignoring error
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.LinkedList.checkElementIndex(LinkedList.java:555)
        at java.util.LinkedList.get(LinkedList.java:476)
        at com.aliyun.emr.rss.client.write.LifecycleManager.handleChangePartitionLocation(LifecycleManager.scala:466)
        at com.aliyun.emr.rss.client.write.LifecycleManager.com$aliyun$emr$rss$client$write$LifecycleManager$$handleRevive(LifecycleManager.scala:425)
        at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:195)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
        at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)

22/06/23 02:21:15 ERROR ShuffleClientImpl: Exception raised while reviving for shuffle 1 reduce 76 epoch 17.
com.aliyun.emr.rss.common.exception.RssException: Exception thrown in awaitResult: 
        at com.aliyun.emr.rss.common.util.ThreadUtils$.awaitResult(ThreadUtils.scala:224)
        at com.aliyun.emr.rss.common.rpc.RpcTimeout.awaitResult(RpcTimeout.scala:74)
        at com.aliyun.emr.rss.common.rpc.RpcEndpointRef.askSync(RpcEndpointRef.scala:92)
        at com.aliyun.emr.rss.common.rpc.RpcEndpointRef.askSync(RpcEndpointRef.scala:76)
        at com.aliyun.emr.rss.client.ShuffleClientImpl.revive(ShuffleClientImpl.java:363)
        at com.aliyun.emr.rss.client.ShuffleClientImpl.submitRetryPushMergedData(ShuffleClientImpl.java:212)
        at com.aliyun.emr.rss.client.ShuffleClientImpl.access$800(ShuffleClientImpl.java:73)
        at com.aliyun.emr.rss.client.ShuffleClientImpl$5.lambda$onFailure$0(ShuffleClientImpl.java:745)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.LinkedList.checkElementIndex(LinkedList.java:555)
        at java.util.LinkedList.get(LinkedList.java:476)
        at com.aliyun.emr.rss.client.write.LifecycleManager.handleChangePartitionLocation(LifecycleManager.scala:466)
        at com.aliyun.emr.rss.client.write.LifecycleManager.com$aliyun$emr$rss$client$write$LifecycleManager$$handleRevive(LifecycleManager.scala:425)
        at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:195)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
        at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
        ... 3 more
22/06/23 02:21:15 ERROR Executor: Exception in task 19645.0 in stage 5.0 (TID 199882)
java.io.IOException: Revive Failed in retry push merged data for location: PartitionLocation[76-17 10.169.28.150:26667:25771:32131:33033 Mode: Master peer: 10.169.28.100:37055:24485:22787]
        at com.aliyun.emr.rss.client.ShuffleClientImpl.submitRetryPushMergedData(ShuffleClientImpl.java:214)
        at com.aliyun.emr.rss.client.ShuffleClientImpl.access$800(ShuffleClientImpl.java:73)
        at com.aliyun.emr.rss.client.ShuffleClientImpl$5.lambda$onFailure$0(ShuffleClientImpl.java:745)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)```

It happened  with below process
```
1. call handleRevive
2. call handleChangePartitionLocation
3. call reallocateSlotsFromCandidates return slot Map(worker1 -> (List(location1), List()), worker2 -> (List(), List(location2)))
3. call reserveSlotsWithRetry for slots, and master location1 failed
4. remove worker1's entity in slots, slots: Map(worker2 -> (List(), List(location2))
5. remove slave's partition when destory partition slots: Map(worker2 -> (List(), List())
6. retryCandidates , got retry slots Map(worker3 -> (List(partition3), List()), worker4 -> (List(), List(partition4)))
7. add retryCandidate's slots to slots  Map(worker2 -> (List(), List()), worker3 -> (List(partition3), List()), worker4 -> (List(), List(partition4)))
8. returned slots have an entity with both empty master and slave PartitionLocation.
```
throw exception in below logic
```
    val location = if (masters != null && masters.size() > 0) {
      masters.get(0)
    } else {
      slaves.get(0).getPeer
    }
```

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
