### PR TITLE
[BUG] Fix worker pushserverPort and replicateServerPort conflict

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -574,6 +574,10 @@ object RssConf extends Logging {
     conf.getInt("rss.fetchserver.port", 0)
   }
 
+  def replicateServerPort(conf: RssConf): Int = {
+    conf.getInt("rss.replicateserver.port", 0)
+  }
+
   def registerWorkerTimeoutMs(conf: RssConf): Long = {
     conf.getTimeAsMs("rss.register.worker.timeout", "180s")
   }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
@@ -112,7 +112,7 @@ private[deploy] class Worker(
       new TransportContext(transportConf, rpcHandler, closeIdleConnections, workerSource,
         replicateLimiter)
     val serverBootstraps = new jArrayList[TransportServerBootstrap]()
-    transportContext.createServer(RssConf.pushServerPort(conf), serverBootstraps)
+    transportContext.createServer(RssConf.replicateServerPort(conf), serverBootstraps)
   }
 
   private val fetchServer = {


### PR DESCRIPTION
# [BUG]/[FEATURE] Fix worker pushserverPort and replicateServerPort conflict

### What changes were proposed in this pull request?
Fix worker pushserverPort and replicateServerPort conflict

### Why are the changes needed?
add rss.replicateserver.port configuration item


### What are the items that need reviewer attention?

### Related issues.
https://github.com/alibaba/RemoteShuffleService/issues/164

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
