### PR TITLE
[ISSUE-171][BUG] LifeCycleManager throw cala.collection.immutable.HashMap$HashTrieMap cannot be cast to java.util.HashMap when handle destroyBuffersWithRetry

### DIFF
--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -949,8 +949,7 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
         } else {
           // destroy success buffers
           val destroyAfterRetry = retrySlots.asScala.filterKeys(!failedAfterRetry.contains(_)).toMap
-          destroyBuffersWithRetry(applicationId, shuffleId,
-            destroyAfterRetry.asInstanceOf[WorkerResource])
+          destroyBuffersWithRetry(applicationId, shuffleId, new WorkerResource(destroyAfterRetry.asJava))
         }
       }
 

--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -949,7 +949,8 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
         } else {
           // destroy success buffers
           val destroyAfterRetry = retrySlots.asScala.filterKeys(!failedAfterRetry.contains(_)).toMap
-          destroyBuffersWithRetry(applicationId, shuffleId, new WorkerResource(destroyAfterRetry.asJava))
+          destroyBuffersWithRetry(applicationId, shuffleId,
+            new WorkerResource(destroyAfterRetry.asJava))
         }
       }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

```
22/06/27 16:37:53 ERROR Inbox: Ignoring error
java.lang.ClassCastException: scala.collection.immutable.HashMap$HashTrieMap cannot be cast to java.util.HashMap
	at com.aliyun.emr.rss.client.write.LifecycleManager.reserveSlotsWithRetry(LifecycleManager.scala:948)
	at com.aliyun.emr.rss.client.write.LifecycleManager.handleRegisterShuffle(LifecycleManager.scala:302)
	at com.aliyun.emr.rss.client.write.LifecycleManager$$anonfun$receiveAndReply$1.applyOrElse(LifecycleManager.scala:188)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
