### PR TITLE
[ISSUE-281][BUG] Use correct maxDestLength to check if buffer can satisfy compress result

### DIFF
--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
@@ -42,8 +42,8 @@ public class RssLz4Compressor extends RssLz4Trait {
     initCompressBuffer(blockSize);
   }
 
-  private void initCompressBuffer(int size) {
-    int compressedBlockSize = HEADER_LENGTH + compressor.maxCompressedLength(size);
+  private void initCompressBuffer(int maxDestLength) {
+    int compressedBlockSize = HEADER_LENGTH + maxDestLength;
     compressedBuffer = new byte[compressedBlockSize];
     System.arraycopy(MAGIC, 0, compressedBuffer, 0, MAGIC_LENGTH);
   }
@@ -52,8 +52,9 @@ public class RssLz4Compressor extends RssLz4Trait {
     checksum.reset();
     checksum.update(data, offset, length);
     final int check = (int) checksum.getValue();
-    if (compressedBuffer.length - HEADER_LENGTH < length) {
-      initCompressBuffer(length);
+    int maxDestLength = compressor.maxCompressedLength(length);
+    if (compressedBuffer.length - HEADER_LENGTH < maxDestLength) {
+      initCompressBuffer(maxDestLength);
     }
     int compressedLength = compressor.compress(
         data, offset, length, compressedBuffer, HEADER_LENGTH);


### PR DESCRIPTION
### What changes were proposed in this pull request?
We encounter issue 
<img width="1781" alt="image" src="https://user-images.githubusercontent.com/46485123/180948291-d9eeaf49-c53b-45b1-8a43-45977b6f0c96.png">

in compress method , it require `maxDestLen >= maxCompressedLength(srcLen)`
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/46485123/180948354-ba5a20c7-381b-4613-9052-782f4d439eab.png">

But we use `length` to check
```
if (compressedBuffer.length - HEADER_LENGTH < length) 
```
but ` maxCompressedLength(length)` can  greater than  `length`, then cause this issue.

<img width="886" alt="image" src="https://user-images.githubusercontent.com/46485123/180948762-298ce843-81bc-47a9-9220-161f43650499.png">

 

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
