### PR TITLE
ShuffleBlockInfo should be static inner class

### DIFF
--- a/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/PartitionFilesSorter.java
+++ b/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/PartitionFilesSorter.java
@@ -293,7 +293,7 @@ public class PartitionFilesSorter {
       getChunkOffsets(startMapIndex, endMapIndex, sortedFileName, indexMap));
   }
 
-  class ShuffleBlockInfo {
+  static class ShuffleBlockInfo {
     protected long offset;
     protected long length;
   }


### PR DESCRIPTION
# ShuffleBlockInfo should be static inner class

### What changes were proposed in this pull request?

mark `ShuffleBlockInfo` static

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Perf improvement, to avoid creating unnecessary outer class

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?

Existing test

/cc @related-reviewer

/assign @main-reviewer
