### PR TITLE
[ISSUE-305][FEATURE] Add metrics for marking active master

### DIFF
--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -100,6 +100,9 @@ private[deploy] class Master(
           true
         }
       })
+    // is master active under HA mode
+    source.addGauge(MasterSource.IsActiveMaster,
+      _ => isMasterActive)
 
     metricsSystem.registerSource(source)
     metricsSystem.registerSource(new JVMSource(conf, MetricsSystem.ROLE_MASTER))
@@ -527,6 +530,20 @@ private[deploy] class Master(
         logError(s"AskSync ThreadDump failed.", e)
         ThreadDumpResponse("Unknown")
     }
+  }
+
+  private def isMasterActive: Int = {
+    // use int rather than bool for better monitoring on dashboard
+    val isActive = if (haEnabled(conf)) {
+      if (statusSystem.asInstanceOf[HAMasterMetaManager].getRatisServer.isLeader) {
+        1
+      } else {
+        0
+      }
+    } else {
+      1
+    }
+    isActive
   }
 }
 

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/MasterSource.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/MasterSource.scala
@@ -45,4 +45,6 @@ object MasterSource {
 
   val RegisteredShuffleCount = "RegisteredShuffleCount"
 
+  val IsActiveMaster = "IsActiveMaster"
+
 }


### PR DESCRIPTION
[ISSUE-305][FEATURE] Add metrics for marking active master

### What changes were proposed in this pull request?
Add metric to monitor the status of master, if it is active under HA mode.

### Why are the changes needed?
In order to be more convenient to check the active master under HA mode in dashboard. Using the Int instead of Boolean type to represent the status could more intuitively observe the election status of the Ratis cluster.

### What are the items that need reviewer attention?
Using Int instead of Boolean or IP to represent status.

### Related issues.
#305 

### Related pull requests.


### How was this patch tested?
unit test

/cc @AngersZhuuuu 

/assign @main-reviewer
