### PR TITLE
[ISSUE-304][BUG]HA port being occupied makes master cannot normally launch

### DIFF
--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
@@ -17,12 +17,9 @@
 
 package com.aliyun.emr.rss.service.deploy.master.clustermeta.ha;
 
-import java.io.IOException;
-import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
-import java.net.ServerSocket;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -111,12 +108,6 @@ public class HANodeDetails {
       }
 
       if (!addr.isUnresolved() && isLocalAddress(addr.getAddress())) {
-        if (isLocalPortOccupied(addr.getPort())) {
-          throwConfException("This machine's Ratis port %s has been occupied, " +
-              "please refer to configuration guide to set it as another port " +
-              "in config file for all nodes.", Integer.toString(ratisPort));
-          return null;
-        }
         localRpcAddress = addr;
         localServiceId = serviceId;
         localNodeId = nodeId;
@@ -168,28 +159,5 @@ public class HANodeDetails {
     }
 
     return local;
-  }
-
-  public static boolean isLocalPortOccupied(int port) {
-    ServerSocket ss = null;
-    DatagramSocket ds = null;
-    try {
-      ss = new ServerSocket(port);
-      ds = new DatagramSocket(port);
-      return false;
-    } catch (Exception e) {
-      return true;
-    } finally {
-      if (ds != null) {
-        ds.close();
-      }
-      try {
-        if (ss != null) {
-          ss.close();
-        }
-      } catch (IOException ioe) {
-        // nothing to do
-      }
-    }
   }
 }

--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
@@ -17,9 +17,11 @@
 
 package com.aliyun.emr.rss.service.deploy.master.clustermeta.ha;
 
+import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
+import java.net.ServerSocket;
 import java.net.SocketException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -108,6 +110,11 @@ public class HANodeDetails {
       }
 
       if (!addr.isUnresolved() && isLocalAddress(addr.getAddress())) {
+        if (isLocalPortOccupied(addr.getPort())) {
+          throwConfException("This machine's Ratis port %s has been occupied, please refer to configuration " +
+                  "guide to set it as another port in config file for all nodes.", Integer.toString(ratisPort));
+          return null;
+        }
         localRpcAddress = addr;
         localServiceId = serviceId;
         localNodeId = nodeId;
@@ -159,5 +166,13 @@ public class HANodeDetails {
     }
 
     return local;
+  }
+
+  public static boolean isLocalPortOccupied(int port) {
+    try (ServerSocket ss = new ServerSocket(port); DatagramSocket ds = new DatagramSocket(port)) {
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
 }

--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
@@ -17,6 +17,7 @@
 
 package com.aliyun.emr.rss.service.deploy.master.clustermeta.ha;
 
+import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -170,10 +171,25 @@ public class HANodeDetails {
   }
 
   public static boolean isLocalPortOccupied(int port) {
-    try (ServerSocket ss = new ServerSocket(port); DatagramSocket ds = new DatagramSocket(port)) {
+    ServerSocket ss = null;
+    DatagramSocket ds = null;
+    try {
+      ss = new ServerSocket(port);
+      ds = new DatagramSocket(port);
       return false;
     } catch (Exception e) {
       return true;
+    } finally {
+      if (ds != null) {
+        ds.close();
+      }
+      try {
+        if (ss != null) {
+          ss.close();
+        }
+      } catch (IOException ioe) {
+        // nothing to do
+      }
     }
   }
 }

--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HANodeDetails.java
@@ -111,8 +111,9 @@ public class HANodeDetails {
 
       if (!addr.isUnresolved() && isLocalAddress(addr.getAddress())) {
         if (isLocalPortOccupied(addr.getPort())) {
-          throwConfException("This machine's Ratis port %s has been occupied, please refer to configuration " +
-                  "guide to set it as another port in config file for all nodes.", Integer.toString(ratisPort));
+          throwConfException("This machine's Ratis port %s has been occupied, " +
+              "please refer to configuration guide to set it as another port " +
+              "in config file for all nodes.", Integer.toString(ratisPort));
           return null;
         }
         localRpcAddress = addr;
@@ -170,9 +171,9 @@ public class HANodeDetails {
 
   public static boolean isLocalPortOccupied(int port) {
     try (ServerSocket ss = new ServerSocket(port); DatagramSocket ds = new DatagramSocket(port)) {
-      return true;
-    } catch (Exception e) {
       return false;
+    } catch (Exception e) {
+      return true;
     }
   }
 }

--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HARaftServer.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/clustermeta/ha/HARaftServer.java
@@ -539,4 +539,8 @@ public class HARaftServer {
   public String getRaftAddress() {
     return this.masterRatisAddress.getAddress().getHostAddress();
   }
+
+  public int getRaftPort() {
+    return this.masterRatisAddress.getPort();
+  }
 }

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -65,12 +65,7 @@ private[deploy] class Master(
           System.exit(1)
         } else {
           logError("Face unexpected IO exception during staring Ratis server", ioe)
-          throw ioe
         }
-      case e: Exception =>
-        logError("Face unexpected exception during staring Ratis server", e)
-        throw e
-      case _ => // nothing to do
     }
     sys
   } else {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Ratis HA port being occupied makes master cannot normally launch

### Why are the changes needed?
In original logic, it doesn't check if the port is occupied here, it will only check if the port is located in the valid port range.
<img width="585" alt="image" src="https://user-images.githubusercontent.com/30563796/183846205-3d592c76-24e5-4db0-92ad-213c7a00fdbc.png">
And if the HA port is occupied (images pasted in Issue), it will throw below exception during Ratis server’s learder election, then make the Master's process stuck there and block the other component's initialization such as prometheus http endpoint.
So it is necessary to check whether the HA is occupied before the Ratis server launch, and exit the Master process if it is.

After changed, Master will throw below exception if HA port is occupied.
```
starting com.aliyun.emr.rss.service.deploy.master.Master, logging to /var/log/rss/rss-root-com.aliyun.emr.rss.service.deploy.master.xxxx.xxxr.xxx.io.out
failed to launch: nice -n 0 /usr/share/rss/bin/rss-class com.aliyun.emr.rss.service.deploy.master.Master
  Exception in thread "main" java.lang.IllegalArgumentException: This machine's Ratis port 9872 has been occupied, please refer to configuration guide to set it as another port in config file for all nodes.
  	at com.aliyun.emr.rss.service.deploy.master.clustermeta.ha.HANodeDetails.throwConfException(HANodeDetails.java:151)
  	at com.aliyun.emr.rss.service.deploy.master.clustermeta.ha.HANodeDetails.loadHAConfig(HANodeDetails.java:110)
  	at com.aliyun.emr.rss.service.deploy.master.clustermeta.ha.MetaHandler.setUpMasterRatisServer(MetaHandler.java:44)
  	at com.aliyun.emr.rss.service.deploy.master.Master.<init>(Master.scala:56)
  	at com.aliyun.emr.rss.service.deploy.master.Master$.main(Master.scala:555)
  	at com.aliyun.emr.rss.service.deploy.master.Master.main(Master.scala)
full log in /var/log/rss/rss-root-com.aliyun.emr.rss.service.deploy.master.xxx.xxx.xxx.io.out
```
### What are the items that need reviewer attention?


### Related issues.
#304 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
