### PR TITLE
Build: Enhance build system

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,39 +10,30 @@ on:
     branches: [ main ]
 
 jobs:
-  build_rss_on_spark_2:
+  build_rss_on_spark:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - 8
+        spark:
+          - '2.4'
+          - '3.0'
     steps:
     - uses: actions/checkout@v2
-    - name: Setup Maven Action
-      uses: s4u/setup-maven-action@v1.3.1
+    - name: Setup JDK ${{ matrix.java }}
+      uses: actions/setup-java@v2
       with:
-        java-version: 8
-        maven-version: 3.6.3
+        distribution: zulu
+        java-version: ${{ matrix.java }}
+        cache: maven
+        check-latest: false
     - name: Build with Maven
-      run: mvn install -DskipTests -Pspark-2 -Plog4j-1
+      run: build/mvn -Pspark-${{ matrix.spark }} -Plog4j-1 install -DskipTests
     - name: Check Java Code Style
-      run: mvn checkstyle:check -Pspark-2
+      run: build/mvn -Pspark-${{ matrix.spark }} -Plog4j-1 checkstyle:check
     - name: Check Scale Code Style
-      run: mvn scalastyle:check -Pspark-2
+      run: build/mvn -Pspark-${{ matrix.spark }} -Plog4j-1 scalastyle:check
     - name: Unit Test
-      run: mvn test -Pspark-2 -Plog4j-1
-  build_rss_on_spark_3:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Setup Maven Action
-      uses: s4u/setup-maven-action@v1.3.1
-      with:
-        java-version: 8
-        maven-version: 3.6.3
-    - name: Build with Maven
-      run: mvn install -DskipTests -Pspark-3 -Plog4j-1
-    - name: Check Java Code Style
-      run: mvn checkstyle:check -Pspark-3
-    - name: Check Scale Code Style
-      run: mvn scalastyle:check -Pspark-3
-    - name: Unit Test
-      run: mvn test -Pspark-3 -Plog4j-1
-    needs: build_rss_on_spark_2
-
+      run: build/mvn -Pspark-${{ matrix.spark }} -Plog4j-1 test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,8 @@ Any contributions from the open-source community to improve this project are wel
 ## Code Style
 This project uses check-style plugins. Run some checks before you create a new pull request.
 ```shell
-mvn clean -Pspark-2 -Plog4j-1/-Plog4j-2
-mvn install -DskipTests -Pspark-2 -Plog4j-1/-Plog4j-2
-mvn checkstyle:check -Pspark-2
-mvn scalastyle:check -Pspark-2
-mvn test -Pspark-2 -Plog4j-1/-Plog4j-2
+dev/check-spark-2.4.sh
+dev/check-spark-3.0.sh
 ```
 
 ## How to Contribute

--- a/README.md
+++ b/README.md
@@ -44,16 +44,11 @@ RSS Worker's slot count is decided by `rss.worker.numSlots` or`rss.worker.flush.
 RSS worker's slot count decreases when a partition is allocated and increments when a partition is freed.
 
 ## Build
-RSS supports Spark2.x(>=2.4.0), Spark3.x(>=3.0.1) and only tested under Java8(JDK1.8).
+RSS supports Spark 2.4/3.0 and only tested under Java 8.
 
-Build for Spark 2    
+Build for Spark
 `
-./dev/make-distribution.sh -Pspark-2 -Plog4j-1/-Plog4j-2
-`
-
-Build for Spark 3  
-`
-./dev/make-distribution.sh -Pspark-3 -Plog4j-1/-Plog4j-2
+./dev/make-distribution.sh -Pspark-2.4/-Pspark-3.0 -Plog4j-1/-Plog4j-2
 `
 
 package rss-${project.version}-bin-release.tgz will be generated.
@@ -67,14 +62,14 @@ Build procedure will create a compressed package.
     ├── master-jars                     
     ├── worker-jars                     
     ├── sbin                            
-    └── spark                       //Spark client jars
+    └── spark          // Spark client jars
 ```
 
 ### Compatibility
-RSS server is compatible with both Spark2 and Spark3.
-You can run both Spark2 and Spark3 with the same RSS server. It doesn't matter whether RSS server is compiled with -Pspark-2 or -Pspark-3.
+RSS server is compatible with all supported Spark versions.
+You can run different Spark versions with the same RSS server. It doesn't matter whether RSS server is compiled with -Pspark-2.4/3.0.
 However, RSS client must be consistent with the version of the Spark.
-That is, if you are running Spark2, you must compile RSS client with -Pspark-2; if you are running Spark3, you must compile RSS client with -Pspark-3.
+For example, if you are running Spark 2.4, you must compile RSS client with -Pspark-2.4; if you are running Spark 3.0, you must compile RSS client with -Pspark-3.0.
 
 ## Usage
 RSS supports HA mode deployment.

--- a/build/mvn
+++ b/build/mvn
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Determine the current working directory
+_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+# Preserve the calling directory
+_CALLING_DIR="$(pwd)"
+# Options used during compilation
+_COMPILE_JVM_OPTS="-Xms2g -Xmx2g -XX:ReservedCodeCacheSize=1g -Xss128m"
+
+if [ "$CI" ]; then
+  export MAVEN_CLI_OPTS="--no-transfer-progress --errors --fail-fast"
+fi
+
+# Installs any application tarball given a URL, the expected tarball name,
+# and, optionally, a checkable binary path to determine if the binary has
+# already been installed
+## Arg1 - URL
+## Arg2 - Tarball Name
+## Arg3 - Checkable Binary
+install_app() {
+  local remote_tarball="$1/$2"
+  local local_tarball="${_DIR}/$2"
+  local binary="${_DIR}/$3"
+
+  # setup `curl` and `wget` silent options if we're running on Jenkins
+  local curl_opts="-L"
+  local wget_opts=""
+  curl_opts="--progress-bar ${curl_opts}"
+  wget_opts="--progress=bar:force ${wget_opts}"
+
+  if [ -z "$3" -o ! -f "$binary" ]; then
+    # check if we already have the tarball
+    # check if we have curl installed
+    # download application
+    [ ! -f "${local_tarball}" ] && [ $(command -v curl) ] && \
+      echo "exec: curl ${curl_opts} ${remote_tarball}" 1>&2 && \
+      curl ${curl_opts} "${remote_tarball}" > "${local_tarball}"
+    # if the file still doesn't exist, lets try `wget` and cross our fingers
+    [ ! -f "${local_tarball}" ] && [ $(command -v wget) ] && \
+      echo "exec: wget ${wget_opts} ${remote_tarball}" 1>&2 && \
+      wget ${wget_opts} -O "${local_tarball}" "${remote_tarball}"
+    # if both were unsuccessful, exit
+    [ ! -f "${local_tarball}" ] && \
+      echo -n "ERROR: Cannot download $2 with cURL or wget; " && \
+      echo "please install manually and try again." && \
+      exit 2
+    cd "${_DIR}" && tar -xzf "$2"
+    rm -rf "$local_tarball"
+  fi
+}
+
+# Determine the Maven version from the root pom.xml file and
+# install maven under the build/ folder if needed.
+install_mvn() {
+  local MVN_VERSION=`grep "<maven.version>" "${_DIR}/../pom.xml" | head -n1 | awk -F '[<>]' '{print $3}'`
+  MVN_BIN="$(command -v mvn)"
+  if [ "$MVN_BIN" ]; then
+    local MVN_DETECTED_VERSION="$(mvn --version | head -n1 | awk '{print $3}')"
+  fi
+  # See simple version normalization: http://stackoverflow.com/questions/16989598/bash-comparing-version-numbers
+  function version { echo "$@" | awk -F. '{ printf("%03d%03d%03d\n", $1,$2,$3); }'; }
+  if [ $(version $MVN_DETECTED_VERSION) -lt $(version $MVN_VERSION) ]; then
+    local APACHE_MIRROR=${APACHE_MIRROR:-'https://archive.apache.org/dist/'}
+
+    install_app \
+      "${APACHE_MIRROR}/maven/maven-3/${MVN_VERSION}/binaries" \
+      "apache-maven-${MVN_VERSION}-bin.tar.gz" \
+      "apache-maven-${MVN_VERSION}/bin/mvn"
+
+    MVN_BIN="${_DIR}/apache-maven-${MVN_VERSION}/bin/mvn"
+  fi
+}
+
+install_mvn
+
+cd "${_CALLING_DIR}"
+
+# Set any `mvn` options if not already present
+export MAVEN_OPTS=${MAVEN_OPTS:-"$_COMPILE_JVM_OPTS"}
+
+echo "Using \`mvn\` from path: $MVN_BIN" 1>&2
+${MVN_BIN} $MAVEN_CLI_OPTS "$@"

--- a/client-spark/shuffle-manager-2/pom.xml
+++ b/client-spark/shuffle-manager-2/pom.xml
@@ -27,7 +27,7 @@
 
     <artifactId>rss-shuffle-manager</artifactId>
     <packaging>jar</packaging>
-    <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark </name>
+    <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 2</name>
 
     <dependencies>
         <dependency>
@@ -35,45 +35,40 @@
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>client</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.aliyun.emr</groupId>
-            <artifactId>client</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>shuffle-manager-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aliyun.emr</groupId>
+            <artifactId>client</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <scope>provided</scope>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -92,7 +87,6 @@
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock_${scala.binary.version}</artifactId>
-            <version>${scalamock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/client-spark/shuffle-manager-2/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
+++ b/client-spark/shuffle-manager-2/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
@@ -110,7 +110,7 @@ class RssShuffleReader[K, C](
         context.taskMetrics().incDiskBytesSpilled(sorter.diskBytesSpilled)
         context.taskMetrics().incPeakExecutionMemory(sorter.peakMemoryUsedBytes)
         // Use completion callback to stop sorter if task was finished/cancelled.
-        context.addTaskCompletionListener[Unit](_ => {
+        context.addTaskCompletionListener(_ => {
           sorter.stop()
         })
         CompletionIterator[Product2[K, C], Iterator[Product2[K, C]]](sorter.iterator, sorter.stop())

--- a/client-spark/shuffle-manager-3/pom.xml
+++ b/client-spark/shuffle-manager-3/pom.xml
@@ -27,14 +27,9 @@
 
     <artifactId>rss-shuffle-manager</artifactId>
     <packaging>jar</packaging>
-    <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark </name>
+    <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 3</name>
 
     <dependencies>
-        <dependency>
-            <groupId>com.aliyun.emr</groupId>
-            <artifactId>client</artifactId>
-            <version>${project.version}</version>
-        </dependency>
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>common</artifactId>
@@ -44,35 +39,36 @@
             <groupId>com.aliyun.emr</groupId>
             <artifactId>client</artifactId>
             <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>shuffle-manager-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.aliyun.emr</groupId>
+            <artifactId>client</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <scope>provided</scope>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/client-spark/shuffle-manager-common/pom.xml
+++ b/client-spark/shuffle-manager-common/pom.xml
@@ -35,12 +35,17 @@
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>client</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>client</artifactId>
@@ -48,27 +53,17 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <scope>provided</scope>
         </dependency>
-
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -48,7 +48,6 @@
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -39,86 +39,71 @@
       <groupId>org.apache.ratis</groupId>
       <artifactId>ratis-client</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
     </dependency>
-
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-graphite</artifactId>
-      <version>${codahale.metrics.version}</version>
-      <scope>compile</scope>
     </dependency>
-
     <dependency>
       <groupId>io.dropwizard.metrics</groupId>
       <artifactId>metrics-jvm</artifactId>
-      <version>${codahale.metrics.version}</version>
-      <scope>compile</scope>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jul-to-slf4j</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
     </dependency>
-
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-crypto</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.fusesource.leveldbjni</groupId>
       <artifactId>leveldbjni-all</artifactId>
-      <version>1.8</version>
     </dependency>
-
-    <dependency>
-      <groupId>io.dropwizard.metrics</groupId>
-      <artifactId>metrics-core</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
-
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-crypto</artifactId>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
     </dependency>
-
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-reflect</artifactId>
-      <version>${scala.version}</version>
     </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>junit</groupId>
@@ -147,7 +132,7 @@
       <extension>
         <groupId>kr.motd.maven</groupId>
         <artifactId>os-maven-plugin</artifactId>
-        <version>1.5.0.Final</version>
+        <version>${maven.plugin.os.version}</version>
       </extension>
     </extensions>
     <plugins>
@@ -167,7 +152,7 @@
       <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
-        <version>${protobuf-maven-plugin.version}</version>
+        <version>${maven.plugin.protobuf.version}</version>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/dev/check-spark-2.4.sh
+++ b/dev/check-spark-2.4.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+RSS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
+
+$RSS_HOME/dev/check.sh -Pspark-2.4 -Plog4j-1

--- a/dev/check-spark-3.0.sh
+++ b/dev/check-spark-3.0.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+RSS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
+
+$RSS_HOME/dev/check.sh -Pspark-3.0 -Plog4j-1

--- a/dev/check.sh
+++ b/dev/check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# usage: check.sh <maven build options>
+
+MVN_PROFILE="$@"
+
+RSS_HOME="$(cd "`dirname "$0"`/.."; pwd)"
+MVN="$RSS_HOME/build/mvn"
+
+$MVN $MVN_PROFILE clean
+$MVN $MVN_PROFILE install -DskipTests
+$MVN $MVN_PROFILE checkstyle:check
+$MVN $MVN_PROFILE scalastyle:check

--- a/dev/checkForSpark2.sh
+++ b/dev/checkForSpark2.sh
@@ -1,4 +1,0 @@
-mvn clean -Pspark-2 -Plog4j-1
-mvn install -DskipTests -Pspark-2 -Plog4j-1
-mvn checkstyle:check -Pspark-2 -Plog4j-1
-mvn scalastyle:check -Pspark-2 -Plog4j-1

--- a/dev/checkForSpark3.sh
+++ b/dev/checkForSpark3.sh
@@ -1,4 +1,0 @@
-mvn clean -Pspark-3 -Plog4j-1
-mvn install -DskipTests -Pspark-3 -Plog4j-1
-mvn checkstyle:check -Pspark-3 -Plog4j-1
-mvn scalastyle:check -Pspark-3 -Plog4j-1

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -13,7 +13,7 @@ function exit_with_usage {
   echo "make-distribution.sh - tool for making binary distributions of Remote Shuffle Service"
   echo ""
   echo "usage:"
-  cl_options="[--name]"
+  cl_options="[--name <custom_name>]"
   echo "make-distribution.sh $cl_options <maven build options>"
   echo ""
   exit 1
@@ -44,11 +44,11 @@ while (( "$#" )); do
   shift
 done
 
-MVN="mvn"
+MVN="$RSS_HOME/build/mvn"
 
 if [ -z "$JAVA_HOME" ]; then
   # Fall back on JAVA_HOME from rpm, if found
-  if [ $(command -v  rpm) ]; then
+  if [ $(command -v rpm) ]; then
     RPM_JAVA_HOME="$(rpm -E %java_home 2>/dev/null)"
     if [ "$RPM_JAVA_HOME" != "%java_home" ]; then
       JAVA_HOME="$RPM_JAVA_HOME"

--- a/pom.xml
+++ b/pom.xml
@@ -31,27 +31,48 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <java.version>1.8</java.version>
+
+    <java.version>8</java.version>
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <maven.version>3.6.3</maven.version>
-    <slf4j.version>1.7.16</slf4j.version>
-    <guava.version>14.0.1</guava.version>
-    <CodeCacheSize>512m</CodeCacheSize>
+
+    <checkstyle.version>8.23</checkstyle.version>
     <codahale.metrics.version>3.2.6</codahale.metrics.version>
-    <javaxservlet.version>3.1.0</javaxservlet.version>
-    <!-- Apache Ratis version -->
-    <ratis.version>2.3.0</ratis.version>
-    <!-- gRPC version, used for protoc-gen-grpc-java plugin to download -->
-    <!-- protoc-gen-grpc-java JAR -->
+    <commons-lang3.version>3.10</commons-lang3.version>
+    <commons-io.version>2.8.0</commons-io.version>
+    <commons-crypto.version>1.0.0</commons-crypto.version>
+    <google.jsr305.version>1.3.9</google.jsr305.version>
     <grpc.version>1.44.0</grpc.version>
-    <!-- ProtocolBuffer version, used to verify the protoc version and -->
-    <!-- define the protobuf JAR version                               -->
-    <protobuf.version>3.19.2</protobuf.version><!-- Maven protoc compiler -->
-    <protobuf-maven-plugin.version>0.5.1</protobuf-maven-plugin.version>
+    <guava.version>14.0.1</guava.version>
+    <javaxservlet.version>3.1.0</javaxservlet.version>
+    <junit.version>4.12</junit.version>
+    <leveldb.version>1.8</leveldb.version>
+    <log4j.version>1.2.17</log4j.version>
+    <log4j2.version>2.17.1</log4j2.version>
+    <lz4-java.version>1.8.0</lz4-java.version>
+    <mockito.version>1.10.19</mockito.version>
+    <mockito-scalatest.version>1.16.37</mockito-scalatest.version>
+    <netty.version>4.1.77.Final</netty.version>
+    <protobuf.version>3.19.2</protobuf.version>
+    <ratis.version>2.3.0</ratis.version>
+    <scalamock.version>5.1.0</scalamock.version>
+    <scalatest.version>3.2.3</scalatest.version>
+    <slf4j.version>1.7.16</slf4j.version>
+
+    <maven.plugin.checkstyle.version>3.0.0</maven.plugin.checkstyle.version>
+    <maven.plugin.git.version>4.9.10</maven.plugin.git.version>
+    <maven.plugin.jar.version>3.0.2</maven.plugin.jar.version>
+    <maven.plugin.os.version>1.5.0.Final</maven.plugin.os.version>
+    <maven.plugin.protobuf.version>0.5.1</maven.plugin.protobuf.version>
+    <maven.plugin.scala.version>3.3.2</maven.plugin.scala.version>
+    <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
+    <maven.plugin.scalatest.version>1.0</maven.plugin.scalatest.version>
+    <maven.plugin.shade.version>2.4.3</maven.plugin.shade.version>
+    <maven.plugin.surefire.version>2.22.0</maven.plugin.surefire.version>
+
     <!-- Allow modules to enable / disable certain build plugins easily. -->
     <build.testJarPhase>prepare-package</build.testJarPhase>
-    <scalamock.version>5.1.0</scalamock.version>
   </properties>
 
   <modules>
@@ -66,9 +87,6 @@
 
   <repositories>
     <repository>
-      <!--
-        This is used as a fallback when the first try fails.
-      -->
       <id>central</id>
       <name>Maven Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
@@ -97,16 +115,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.apache.spark</groupId>
-        <artifactId>spark-tags_${scala.binary.version}</artifactId>
-        <version>${spark.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.guava</groupId>
-        <artifactId>guava</artifactId>
-        <version>${guava.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${slf4j.version}</version>
@@ -125,37 +133,81 @@
         <groupId>org.slf4j</groupId>
         <artifactId>jcl-over-slf4j</artifactId>
         <version>${slf4j.version}</version>
-        <!-- runtime scope is appropriate, but causes SBT build problems -->
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <scope>test</scope>
-        <version>4.12</version>
+        <groupId>log4j</groupId>
+        <artifactId>log4j</artifactId>
+        <version>${log4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest_${scala.binary.version}</artifactId>
-        <scope>test</scope>
-        <version>3.2.3</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-slf4j-impl</artifactId>
+        <version>${log4j2.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-funsuite_${scala.binary.version}</artifactId>
-        <scope>test</scope>
-        <version>3.2.3</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-          </exclusion>
-        </exclusions>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-core</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-1.2-api</artifactId>
+        <version>${log4j2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-core</artifactId>
+        <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-graphite</artifactId>
+        <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard.metrics</groupId>
+        <artifactId>metrics-jvm</artifactId>
+        <version>${codahale.metrics.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-common</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-client</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-server</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-netty</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-proto-shaded</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.ratis</groupId>
+        <artifactId>ratis-grpc</artifactId>
+        <version>${ratis.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.scala-lang</groupId>
+        <artifactId>scala-library</artifactId>
+        <version>${scala.version}</version>
       </dependency>
       <dependency>
         <groupId>org.scala-lang</groupId>
@@ -163,39 +215,71 @@
         <version>${scala.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-all</artifactId>
-        <version>4.1.77.Final</version>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-tags_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.10</version>
-        <scope>compile</scope>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-core_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
       </dependency>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
-        <scope>compile</scope>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-core_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <type>test-jar</type>
       </dependency>
       <dependency>
-        <groupId>org.fusesource.leveldbjni</groupId>
-        <artifactId>leveldbjni-all</artifactId>
-        <version>1.8</version>
-        <scope>compile</scope>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.spark</groupId>
+        <artifactId>spark-sql_${scala.binary.version}</artifactId>
+        <version>${spark.version}</version>
+        <type>test-jar</type>
+      </dependency>
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
-        <version>1.3.9</version>
-        <scope>compile</scope>
+        <version>${google.jsr305.version}</version>
+      </dependency>
+      <dependency>
+        <artifactId>protobuf-java</artifactId>
+        <groupId>com.google.protobuf</groupId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.servlet</groupId>
+        <artifactId>javax.servlet-api</artifactId>
+        <version>${javaxservlet.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-all</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-lang3</artifactId>
+        <version>${commons-lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>${commons-io.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-crypto</artifactId>
-        <version>1.0.0</version>
-        <scope>compile</scope>
+        <version>${commons-crypto.version}</version>
         <exclusions>
           <exclusion>
             <artifactId>jna</artifactId>
@@ -204,56 +288,49 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>1.10.19</version>
+        <groupId>org.fusesource.leveldbjni</groupId>
+        <artifactId>leveldbjni-all</artifactId>
+        <version>${leveldb.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.lz4</groupId>
+        <artifactId>lz4-java</artifactId>
+        <version>${lz4-java.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>junit</groupId>
+        <artifactId>junit</artifactId>
         <scope>test</scope>
+        <version>${junit.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.dropwizard.metrics</groupId>
-        <artifactId>metrics-core</artifactId>
-        <version>${codahale.metrics.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.ratis</groupId>
-        <artifactId>ratis-proto-shaded</artifactId>
-        <version>${ratis.version}</version>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest_${scala.binary.version}</artifactId>
+        <scope>test</scope>
+        <version>${scalatest.version}</version>
       </dependency>
       <dependency>
-        <artifactId>ratis-common</artifactId>
-        <groupId>org.apache.ratis</groupId>
-        <version>${ratis.version}</version>
-      </dependency>
-      <dependency>
-        <artifactId>ratis-client</artifactId>
-        <groupId>org.apache.ratis</groupId>
-        <version>${ratis.version}</version>
-      </dependency>
-      <dependency>
-        <artifactId>ratis-server</artifactId>
-        <groupId>org.apache.ratis</groupId>
-        <version>${ratis.version}</version>
-      </dependency>
-      <dependency>
-        <artifactId>ratis-netty</artifactId>
-        <groupId>org.apache.ratis</groupId>
-        <version>${ratis.version}</version>
-      </dependency>
-      <dependency>
-        <artifactId>ratis-grpc</artifactId>
-        <groupId>org.apache.ratis</groupId>
-        <version>${ratis.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.google.protobuf</groupId>
-        <artifactId>protobuf-java</artifactId>
-        <version>${protobuf.version}</version>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-funsuite_${scala.binary.version}</artifactId>
+        <scope>test</scope>
+        <version>${scalatest.version}</version>
       </dependency>
       <dependency>
         <groupId>org.scalamock</groupId>
         <artifactId>scalamock_${scala.binary.version}</artifactId>
         <version>${scalamock.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-core</artifactId>
+        <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.mockito</groupId>
+        <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
+        <version>${mockito-scalatest.version}</version>
+        <scope>test</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -264,7 +341,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.0</version>
+          <version>${maven.plugin.surefire.version}</version>
           <!-- Note config is repeated in scalatest config -->
           <configuration>
             <includes>
@@ -289,7 +366,7 @@
         <plugin>
           <groupId>org.scalatest</groupId>
           <artifactId>scalatest-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>${maven.plugin.scalatest.version}</version>
           <executions>
             <execution>
               <id>test</id>
@@ -302,7 +379,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>2.4.3</version>
+          <version>${maven.plugin.shade.version}</version>
           <executions>
             <execution>
               <phase>package</phase>
@@ -355,7 +432,7 @@
         <plugin>
           <groupId>net.alchim31.maven</groupId>
           <artifactId>scala-maven-plugin</artifactId>
-          <version>3.3.2</version>
+          <version>${maven.plugin.scala.version}</version>
           <executions>
             <execution>
               <id>scala-compile-first</id>
@@ -376,7 +453,7 @@
         <plugin>
           <groupId>pl.project13.maven</groupId>
           <artifactId>git-commit-id-plugin</artifactId>
-          <version>4.9.10</version>
+          <version>${maven.plugin.git.version}</version>
           <executions>
             <execution>
               <id>get-the-git-infos</id>
@@ -403,7 +480,7 @@
       <plugin>
         <groupId>org.scalastyle</groupId>
         <artifactId>scalastyle-maven-plugin</artifactId>
-        <version>1.0.0</version>
+        <version>${maven.plugin.scalastyle.version}</version>
         <configuration>
           <verbose>false</verbose>
           <failOnViolation>true</failOnViolation>
@@ -427,7 +504,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>${maven.plugin.checkstyle.version}</version>
         <configuration>
           <failOnViolation>true</failOnViolation>
           <includeTestSourceDirectory>true</includeTestSourceDirectory>
@@ -447,7 +524,7 @@
           <dependency>
             <groupId>com.puppycrawl.tools</groupId>
             <artifactId>checkstyle</artifactId>
-            <version>8.23</version>
+            <version>${checkstyle.version}</version>
           </dependency>
         </dependencies>
         <executions>
@@ -461,7 +538,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
+        <version>${maven.plugin.jar.version}</version>
         <executions>
           <execution>
             <id>prepare-test-jar</id>
@@ -482,35 +559,34 @@
 
   <profiles>
     <profile>
-      <id>spark-2</id>
+      <id>spark-2.4</id>
       <properties>
+        <jackson.version>2.6.7</jackson.version>
+        <jackson.databind.version>2.6.7.3</jackson.databind.version>
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.5</spark.version>
         <rss.shuffle.manager>shuffle-manager-2</rss.shuffle.manager>
       </properties>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-          <version>2.6.7.3</version>
-          <scope>compile</scope>
+          <artifactId>jackson-annotations</artifactId>
+          <version>${jackson.version}</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-          <version>2.6.7</version>
-          <scope>compile</scope>
+          <artifactId>jackson-databind</artifactId>
+          <version>${jackson.databind.version}</version>
         </dependency>
       </dependencies>
     </profile>
 
     <profile>
-      <id>spark-3</id>
+      <id>spark-3.0</id>
       <properties>
+        <jackson.version>2.10.0</jackson.version>
+        <jackson.databind.version>2.10.0</jackson.databind.version>
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.1</spark.version>
@@ -519,32 +595,23 @@
       <dependencies>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-databind</artifactId>
-          <version>2.10.0</version>
-          <scope>compile</scope>
+          <artifactId>jackson-annotations</artifactId>
+          <version>${jackson.version}</version>
         </dependency>
         <dependency>
           <groupId>com.fasterxml.jackson.core</groupId>
-          <artifactId>jackson-annotations</artifactId>
-          <version>2.10.0</version>
-          <scope>compile</scope>
+          <artifactId>jackson-databind</artifactId>
+          <version>${jackson.databind.version}</version>
         </dependency>
       </dependencies>
     </profile>
 
     <profile>
       <id>log4j-1</id>
-      <properties>
-        <log4j.version>1.2.17</log4j.version>
-      </properties>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>log4j</groupId>
           <artifactId>log4j</artifactId>
-          <version>${log4j.version}</version>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>
@@ -555,36 +622,24 @@
 
     <profile>
       <id>log4j-2</id>
-      <properties>
-        <log4j2.version>2.17.1</log4j2.version>
-      </properties>
-      <activation>
-        <activeByDefault>false</activeByDefault>
-      </activation>
       <dependencies>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-slf4j-impl</artifactId>
-          <version>${log4j2.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-api</artifactId>
-          <version>${log4j2.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-core</artifactId>
-          <version>${log4j2.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.logging.log4j</groupId>
           <artifactId>log4j-1.2-api</artifactId>
-          <version>${log4j2.version}</version>
         </dependency>
       </dependencies>
     </profile>
   </profiles>
-
 </project>
-

--- a/server-common/pom.xml
+++ b/server-common/pom.xml
@@ -35,44 +35,30 @@
       <groupId>com.aliyun.emr</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.mockito</groupId>
-          <artifactId>mockito-core</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
-
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>
-
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>javax.servlet-api</artifactId>
-      <version>${javaxservlet.version}</version>
     </dependency>
-
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-crypto</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
     </dependency>
 
     <!-- Test dependencies -->

--- a/server-master/pom.xml
+++ b/server-master/pom.xml
@@ -11,40 +11,50 @@
 
     <artifactId>master</artifactId>
     <packaging>jar</packaging>
-    <name>Aliyun E-MapReduce Shuffle Service Service Master Module</name>
-
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
+    <name>Aliyun E-MapReduce Shuffle Service Master Module</name>
 
     <dependencies>
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
-
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>server-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-server</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-netty</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ratis</groupId>
+            <artifactId>ratis-grpc</artifactId>
         </dependency>
 
         <dependency>
@@ -52,7 +62,6 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
@@ -66,14 +75,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
-            <version>1.16.37</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>scala-library</artifactId>
-                    <groupId>org.scala-lang</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -81,32 +83,6 @@
             <version>3.6.0</version>
             <scope>test</scope>
         </dependency>
-
-        <dependency>
-            <artifactId>ratis-common</artifactId>
-            <groupId>org.apache.ratis</groupId>
-        </dependency>
-        <dependency>
-            <artifactId>ratis-client</artifactId>
-            <groupId>org.apache.ratis</groupId>
-        </dependency>
-        <dependency>
-            <artifactId>ratis-server</artifactId>
-            <groupId>org.apache.ratis</groupId>
-        </dependency>
-        <dependency>
-            <artifactId>ratis-netty</artifactId>
-            <groupId>org.apache.ratis</groupId>
-        </dependency>
-        <dependency>
-            <artifactId>ratis-grpc</artifactId>
-            <groupId>org.apache.ratis</groupId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.protobuf</groupId>
-            <artifactId>protobuf-java</artifactId>
-        </dependency>
-
     </dependencies>
 
     <build>
@@ -114,7 +90,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>${maven.plugin.os.version}</version>
             </extension>
         </extensions>
         <plugins>
@@ -142,7 +118,7 @@
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>${protobuf-maven-plugin.version}</version>
+                <version>${maven.plugin.protobuf.version}</version>
                 <extensions>true</extensions>
                 <executions>
                     <execution>
@@ -167,7 +143,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.9.10</version>
+                <version>${maven.plugin.git.version}</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/server-worker/pom.xml
+++ b/server-worker/pom.xml
@@ -11,12 +11,7 @@
 
     <artifactId>worker</artifactId>
     <packaging>jar</packaging>
-    <name>Aliyun E-MapReduce Shuffle Service Service Worker Module</name>
-
-    <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
-    </properties>
+    <name>Aliyun E-MapReduce Shuffle Service Worker Module</name>
 
     <dependencies>
         <dependency>
@@ -25,47 +20,56 @@
             <version>${project.version}</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.mockito</groupId>
-                    <artifactId>mockito-core</artifactId>
+                    <groupId>org.apache.ratis</groupId>
+                    <artifactId>ratis-common</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>org.apache.ratis</groupId>
                     <artifactId>ratis-client</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.ratis</groupId>
-                    <artifactId>ratis-common</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
-
         <dependency>
             <groupId>com.aliyun.emr</groupId>
             <artifactId>server-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-all</artifactId>
         </dependency>
-
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
-
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
 
         <dependency>
+            <groupId>com.aliyun.emr</groupId>
+            <artifactId>client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun.emr</groupId>
+            <artifactId>master</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.aliyun.emr</groupId>
+            <artifactId>rss-shuffle-manager</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.binary.version}</artifactId>
@@ -79,14 +83,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-scala-scalatest_${scala.binary.version}</artifactId>
-            <version>1.16.37</version>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <artifactId>scala-library</artifactId>
-                    <groupId>org.scala-lang</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
@@ -95,39 +92,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.aliyun.emr</groupId>
-            <artifactId>master</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.aliyun.emr</groupId>
-            <artifactId>client</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.aliyun.emr</groupId>
-            <artifactId>rss-shuffle-manager</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -137,7 +108,7 @@
             <extension>
                 <groupId>kr.motd.maven</groupId>
                 <artifactId>os-maven-plugin</artifactId>
-                <version>1.5.0.Final</version>
+                <version>${maven.plugin.os.version}</version>
             </extension>
         </extensions>
         <plugins>
@@ -170,7 +141,7 @@
             <plugin>
                 <groupId>pl.project13.maven</groupId>
                 <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.9.10</version>
+                <version>${maven.plugin.git.version}</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/server-worker/src/test/scala/com/aliyun/emr/rss/service/deploy/integration/SkewJoinTest.scala
+++ b/server-worker/src/test/scala/com/aliyun/emr/rss/service/deploy/integration/SkewJoinTest.scala
@@ -29,10 +29,11 @@ class SkewJoinTest extends SparkTestBase {
       .set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
       .set("spark.sql.adaptive.autoBroadcastJoinThreshold", "-1")
       .set("spark.sql.autoBroadcastJoinThreshold", "-1")
+      .set("spark.sql.parquet.compression.codec", "gzip")
 
     enableRss(sparkConf)
 
-    val sparkSession = SparkSession.builder().enableHiveSupport().config(sparkConf).getOrCreate()
+    val sparkSession = SparkSession.builder().config(sparkConf).getOrCreate()
     if (sparkSession.version.startsWith("3")) {
       import sparkSession.implicits._
       val df = sparkSession.sparkContext.parallelize(1 to 120000, 8)
@@ -73,7 +74,8 @@ class SkewJoinTest extends SparkTestBase {
         .toDF("fb", "f6", "f7", "f8", "f9")
       df2.createOrReplaceTempView("view2")
       sparkSession.sql("drop table if exists fres")
-      sparkSession.sql("create table fres as select * from view1 a inner join view2 b on a.fa=b.fb where a.fa=1 ")
+      sparkSession.sql("create table fres using parquet as select * from view1 a inner join view2 b on a.fa=b.fb where a.fa=1 ")
+      sparkSession.sql("drop table fres")
     }
   }
 }


### PR DESCRIPTION
# [INFRA] Enhance build system

### What changes were proposed in this pull request?

- `build/mvn` is introduced for auto-downloading Apache Maven if no suitable candidate `mvn` in the PATH, the suitable `mvn` means the version of `mvn` must be equal or great than `maven.version` defined in `pom.xml`
- `spark-2` and `spark-3` are changed into `spark-2.4` and `spark-3.0`, another versions like `spark-3.1`, `spark-3.2` will be added in the following PRs.
- simplify GitHub workflow yaml by using matrix syntax
- enable build cache on GitHub workflow
- extract version of most deps into maven properties

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To make `pom.xml` and CI script more clear and flexible to build w/ different spark versions

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
