### PR TITLE
[ISSUE-322][FEATURE] Worker stop after all PartitionLocation released

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -887,8 +887,16 @@ object RssConf extends Logging {
     }
   }
 
+  def checkSlotsFinishedInterval(conf: RssConf): Long = {
+    conf.getTimeAsMs("rss.worker.checkSlots.interval", "1s")
+  }
+
+  def checkSlotsFinishedTimeoutMs(conf: RssConf): Long = {
+    conf.getTimeAsMs("rss.worker.checkSlots.timeout", "480s")
+  }
+
   def shutdownTimeoutMs(conf: RssConf): Long = {
-    conf.getTimeAsMs("rss.shutdown.timeout", "600s")
+    conf.getTimeAsMs("rss.worker.shutdown.timeout", "600s")
   }
 
   def offerSlotsAlgorithm(conf: RssConf): String = {

--- a/common/src/main/scala/com/aliyun/emr/rss/common/meta/PartitionLocationInfo.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/meta/PartitionLocationInfo.scala
@@ -301,6 +301,8 @@ class PartitionLocationInfo extends Logging {
     getAllIds(shuffleKey, slavePartitionLocations)
   }
 
+  def isEmpty = masterPartitionLocations.isEmpty && slavePartitionLocations.isEmpty
+
   def close(): Unit = {
     logInfo("Start close " + this.getClass.getSimpleName)
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Currently:

- ReserveSlot will add PartitionLocation to PartitionLocationInfo
- DestroySlot will remove corresponding PartitionLocation from PartitionLocationInfo
- CommitFile reply will remove corresponding PartitionLocation from partitionLocationInfo
- OpenStream will directory use file path from StorageInfo

So graceful shut down should only need to wait for all PartitionLocation removed



### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
