### PR TITLE
[ISSUE-396] Incorrectly report Slow Flusher

### DIFF
--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/StorageManager.scala
@@ -94,6 +94,9 @@ private[worker] abstract class Flusher(
     for (i <- 0 until flushAvgTimeWindowSize) {
       avgTimeWindow(i) = (0L, 0L)
     }
+    for (i <- 0 until lastBeginFlushTime.length()) {
+      lastBeginFlushTime.set(i, -1)
+    }
     for (index <- 0 until threadCount) {
       workingQueues(index) = new LinkedBlockingQueue[FlushTask]()
       workers(index) = new Thread(s"$this-$index") {


### PR DESCRIPTION
```
22/08/19 22:09:49,057 ERROR [local-storage-scheduler] LocalDeviceMonitor: Receive report exception, ArrayBuffer(/mnt/disk2/hadoop/rss-worker/shuffle_data, /mnt/disk2/hadoop/rss-worker/shuffle_data), java.io.IOException: Slow Flusher!
```

# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
