### PR TITLE
[ISSUE-407] Add synchronization to FileInfo and workingDirWriters to …

### DIFF
--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileInfo.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileInfo.java
@@ -24,7 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public class FileInfo {
   public final File file;
-  public final ArrayList<Long> chunkOffsets;
+  private final ArrayList<Long> chunkOffsets;
 
   public FileInfo(File file, ArrayList<Long> chunkOffsets) {
     this.file = file;
@@ -37,7 +37,11 @@ public class FileInfo {
     chunkOffsets.add(0L);
   }
 
-  public int numChunks() {
+  public synchronized void addChunkOffset(long bytesFlushed) {
+    chunkOffsets.add(bytesFlushed);
+  }
+
+  public synchronized int numChunks() {
     if (!chunkOffsets.isEmpty()) {
       return chunkOffsets.size() - 1;
     } else {
@@ -45,7 +49,11 @@ public class FileInfo {
     }
   }
 
-  public long getFileLength() {
+  public synchronized long getLastChunkOffset() {
+    return chunkOffsets.get(chunkOffsets.size() - 1);
+  }
+
+  public synchronized long getFileLength() {
     return chunkOffsets.get(chunkOffsets.size() - 1);
   }
 
@@ -53,7 +61,7 @@ public class FileInfo {
     return file;
   }
 
-  public ArrayList<Long> getChunkOffsets() {
+  public synchronized ArrayList<Long> getChunkOffsets() {
     return chunkOffsets;
   }
 

--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileManagedBuffers.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileManagedBuffers.java
@@ -43,7 +43,7 @@ public class FileManagedBuffers {
       offsets = new long[numChunks + 1];
       ArrayList<Long> chunkOffsets = fileInfo.getChunkOffsets();
       for (int i = 0; i <= numChunks; i++) {
-        offsets[i] = fileInfo.getChunkOffsets().get(i);
+        offsets[i] = chunkOffsets.get(i);
       }
     } else {
       offsets = new long[1];

--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileManagedBuffers.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/FileManagedBuffers.java
@@ -19,6 +19,7 @@ package com.aliyun.emr.rss.common.network.server;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.BitSet;
 
 import com.aliyun.emr.rss.common.network.buffer.FileSegmentManagedBuffer;
@@ -40,8 +41,9 @@ public class FileManagedBuffers {
     numChunks = fileInfo.numChunks();
     if (numChunks > 0) {
       offsets = new long[numChunks + 1];
+      ArrayList<Long> chunkOffsets = fileInfo.getChunkOffsets();
       for (int i = 0; i <= numChunks; i++) {
-        offsets[i] = fileInfo.chunkOffsets.get(i);
+        offsets[i] = fileInfo.getChunkOffsets().get(i);
       }
     } else {
       offsets = new long[1];

--- a/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/FileWriter.java
+++ b/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/FileWriter.java
@@ -166,7 +166,7 @@ public final class FileWriter implements DeviceObserver {
 
   private void maybeSetChunkOffsets(boolean forceSet) {
     if (bytesFlushed >= nextBoundary || forceSet) {
-      fileInfo.chunkOffsets.add(bytesFlushed);
+      fileInfo.addChunkOffset(bytesFlushed);
       nextBoundary = bytesFlushed + chunkSize;
     }
   }
@@ -180,7 +180,7 @@ public final class FileWriter implements DeviceObserver {
     // but its size is smaller than the nextBoundary, then the
     // chunk offset will not be set after flushing. we should
     // set it during FileWriter close.
-    return fileInfo.chunkOffsets.get(fileInfo.chunkOffsets.size() - 1) == bytesFlushed;
+    return fileInfo.getLastChunkOffset() == bytesFlushed;
   }
 
   /**

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/StorageManager.scala
@@ -543,12 +543,14 @@ private[worker] final class StorageManager(
   }
 
   private def flushFileWriters(): Unit = {
-    workingDirWriters.asScala.foreach { case (file, writers) =>
-      if (writers != null && writers.size() > 0) {
-        writers.asScala.foreach { case writer =>
-          writer.flushOnMemoryPressure()
-        }
+    val allWriters = new util.HashSet[FileWriter]()
+    workingDirWriters.asScala.foreach { case (_, writers) =>
+      writers.synchronized {
+        allWriters.addAll(writers)
       }
+    }
+    allWriters.asScala.foreach{ case writer =>
+      writer.flushOnMemoryPressure()
     }
   }
 
@@ -570,8 +572,10 @@ private[worker] final class StorageManager(
     disksSnapshot().filter(_.status != DiskStatus.IoHang).foreach { case diskInfo =>
       val totalUsage = diskInfo.dirs.map { dir =>
         val writers = workingDirWriters.get(dir)
-        if (writers != null && writers.size() > 0) {
-          writers.asScala.map(_.getFileInfo.getFileLength).sum
+        if (writers != null) {
+          writers.synchronized {
+            writers.asScala.map(_.getFileInfo.getFileLength).sum
+          }
         } else {
           0
         }

--- a/server-worker/src/test/java/com/aliyun/emr/rss/service/deploy/worker/PartitionFilesSorterSuiteJ.java
+++ b/server-worker/src/test/java/com/aliyun/emr/rss/service/deploy/worker/PartitionFilesSorterSuiteJ.java
@@ -86,7 +86,7 @@ public class PartitionFilesSorterSuiteJ {
       channel.write(ByteBuffer.wrap(mockedData));
     }
     originFileLen = channel.size();
-    fileInfo.chunkOffsets.add(originFileLen);
+    fileInfo.getChunkOffsets().add(originFileLen);
     System.out.println(shuffleFile.getAbsolutePath() +
                          " filelen " + (double) originFileLen / 1024 / 1024.0 + "MB");
 


### PR DESCRIPTION
…fix concurrent issues

```
22/08/22 00:45:31,418 ERROR [worker-forward-message-scheduler] Utils: Uncaught exception in thread worker-forward-message-scheduler
java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:911)
        at java.util.ArrayList$Itr.next(ArrayList.java:861)
        at scala.collection.convert.Wrappers$JIteratorWrapper.next(Wrappers.scala:46)
        at scala.collection.Iterator.foreach(Iterator.scala:943)
        at scala.collection.Iterator.foreach$(Iterator.scala:943)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
        at scala.collection.IterableLike.foreach(IterableLike.scala:74)
        at scala.collection.IterableLike.foreach$(IterableLike.scala:73)
        at scala.collection.AbstractIterable.foreach(Iterable.scala:56)
        at scala.collection.TraversableLike.map(TraversableLike.scala:286)
        at scala.collection.TraversableLike.map$(TraversableLike.scala:279)
        at scala.collection.AbstractTraversable.map(Traversable.scala:108)
        at com.aliyun.emr.rss.service.deploy.worker.StorageManager.$anonfun$updateDiskInfos$3(StorageManager.scala:574)
        at com.aliyun.emr.rss.service.deploy.worker.StorageManager.$anonfun$updateDiskInfos$3$adapted(StorageManager.scala:571)
        at scala.collection.immutable.List.map(List.scala:293)
        at com.aliyun.emr.rss.service.deploy.worker.StorageManager.$anonfun$updateDiskInfos$2(StorageManager.scala:571)
        at com.aliyun.emr.rss.service.deploy.worker.StorageManager.$anonfun$updateDiskInfos$2$adapted(StorageManager.scala:570)
        at scala.collection.immutable.List.foreach(List.scala:431)
        at com.aliyun.emr.rss.service.deploy.worker.StorageManager.updateDiskInfos(StorageManager.scala:570)
        at com.aliyun.emr.rss.service.deploy.worker.Worker.heartBeatToMaster(Worker.scala:195)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anon$1.$anonfun$run$1(Worker.scala:229)
        at com.aliyun.emr.rss.common.util.Utils$.tryLogNonFatalError(Utils.scala:173)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anon$1.run(Worker.scala:229)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:750)
```

```
22/08/22 00:00:50,927 ERROR [push-server-6-3] PushDataHandler: Error while handlePushData PushData{requestId=377408, mode=0, shuffleKey=application_1660226621060_0175-127, partitionUniqueId=446-0, body size=35960}
java.lang.NullPointerException
        at com.aliyun.emr.rss.common.network.server.FileInfo.getFileLength(FileInfo.java:49)
        at com.aliyun.emr.rss.service.deploy.worker.PushDataHandler.handlePushData(PushDataHandler.scala:195)
        at com.aliyun.emr.rss.service.deploy.worker.PushDataHandler.receive(PushDataHandler.scala:72)
        at com.aliyun.emr.rss.common.network.server.TransportRequestHandler.handle(TransportRequestHandler.java:79)
        at com.aliyun.emr.rss.common.network.server.TransportChannelHandler.channelRead(TransportChannelHandler.java:118)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at com.aliyun.emr.rss.common.network.util.TransportFrameDecoder.channelRead(TransportFrameDecoder.java:75)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357)
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379)
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365)
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919)
        at io.netty.channel.nio.AbstractNioByteChannel$NioByteUnsafe.read(AbstractNioByteChannel.java:166)
        at io.netty.channel.nio.NioEventLoop.processSelectedKey(NioEventLoop.java:722)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeysOptimized(NioEventLoop.java:658)
        at io.netty.channel.nio.NioEventLoop.processSelectedKeys(NioEventLoop.java:584)
        at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:496)
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:995)
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74)
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
        at java.lang.Thread.run(Thread.java:750)
```

# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
close #407 


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
