### PR TITLE
[ISSUE-417] handleUnregisterShuffle and StageEnd trigger double handl…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,14 +7,11 @@ assignees: ''
 
 ---
 
-### What is the bug?
+### What is the bug(with logs or screenshots)?
 A clear and concise description of what the bug is.
 
 ### How to reproduce the bug?
 Steps to reproduce the bug.
-
-### Could you share logs or screenshots?
-If applicable, add logs/screenshots to help explain your problem.
 
 /cc @who-need-to-know
 

--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -615,9 +615,13 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
       stageEndShuffleSet.add(shuffleId)
       return
     }
+    if (stageEndShuffleSet.contains(shuffleId)) {
+      logInfo(s"[handleStageEnd] Shuffle $shuffleId already ended!")
+      return
+    }
     inProcessStageEndShuffleSet.synchronized {
       if (inProcessStageEndShuffleSet.contains(shuffleId)) {
-        logWarning(s"handleStageEnd for shuffle $shuffleId is in process!")
+        logWarning(s"[handleStageEnd] Shuffle $shuffleId is in process!")
         return
       }
       inProcessStageEndShuffleSet.add(shuffleId)

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/DeviceMonitor.scala
@@ -142,11 +142,6 @@ class LocalDeviceMonitor(
             val isWriteHang = lastWriteComplete == writeComplete &&
               writeInflight >= lastWriteInflight && lastWriteInflight > 0
 
-            lastReadComplete = readComplete
-            lastWriteComplete = writeComplete
-            lastReadInflight = readInflight
-            lastWriteInflight = writeInflight
-
             if (isReadHang || isWriteHang) {
               logger.info(s"Result of DeviceInfo.checkIoHang, DeviceName: ${deviceInfo.name}" +
                 s"($readComplete,$writeComplete,$readInflight,$writeInflight)\t" +
@@ -155,6 +150,11 @@ class LocalDeviceMonitor(
               )
               logger.error(s"IO Hang! ReadHang: $isReadHang, WriteHang: $isWriteHang")
             }
+
+            lastReadComplete = readComplete
+            lastWriteComplete = writeComplete
+            lastReadInflight = readInflight
+            lastWriteInflight = writeInflight
 
             isReadHang || isWriteHang
           }


### PR DESCRIPTION
…eStageEnd

1. Unregister shuffle triggers handleStageEnd
```
22/08/22 12:47:00 INFO LifecycleManager: Call StageEnd before Unregister Shuffle 60.
```
2. handleStageEnd success, maybe triggered by handleUnregisterShuffle or StageEnd
```
22/08/22 12:47:51 INFO LifecycleManager: Succeed to handle stageEnd for 60.
```
3. reports data lost
```
22/08/22 12:48:28 ERROR LifecycleManager: For 60 partition 2185-0: data lost.
22/08/22 12:48:28 ERROR LifecycleManager: Failed to handle stageEnd for 60, lost file!
```
4. report unregister success
```
22/08/22 12:48:28 INFO LifecycleManager: Unregister for 60 success.
```

# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
close #417 


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
