### PR TITLE
[ISSUE-428]Should not check blacklist when reserveSlots to avoid ping…

### DIFF
--- a/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
+++ b/client/src/main/scala/com/aliyun/emr/rss/client/write/LifecycleManager.scala
@@ -836,23 +836,18 @@ class LifecycleManager(appId: String, val conf: RssConf) extends RpcEndpoint wit
     val parallelism = Math.min(Math.max(1, slots.size()), RssConf.rpcMaxParallelism(conf))
     ThreadUtils.parmap(slots.asScala.to, "ReserveSlot", parallelism) {
       case (workerInfo, (masterLocations, slaveLocations)) =>
-        if (blacklist.contains(workerInfo)) {
-          logWarning(s"[reserve buffer] failed due to blacklist: $workerInfo")
-          reserveSlotFailedWorkers.add(workerInfo)
+        val res = requestReserveSlots(workerInfo.endpoint,
+          ReserveSlots(applicationId, shuffleId, masterLocations, slaveLocations, splitThreshold,
+            splitMode, partitionType))
+        if (res.status.equals(StatusCode.Success)) {
+          logDebug(s"Successfully allocated " +
+            s"partitions buffer for ${Utils.makeShuffleKey(applicationId, shuffleId)}" +
+            s" from worker ${workerInfo.readableAddress()}.")
         } else {
-          val res = requestReserveSlots(workerInfo.endpoint,
-            ReserveSlots(applicationId, shuffleId, masterLocations, slaveLocations, splitThreshold,
-              splitMode, partitionType))
-          if (res.status.equals(StatusCode.Success)) {
-            logDebug(s"Successfully allocated " +
-              s"partitions buffer for ${Utils.makeShuffleKey(applicationId, shuffleId)}" +
-              s" from worker ${workerInfo.readableAddress()}.")
-          } else {
-            logError(s"[reserveSlots] Failed to" +
-              s" reserve buffers for ${Utils.makeShuffleKey(applicationId, shuffleId)}" +
-              s" from worker ${workerInfo.readableAddress()}. Reason: ${res.reason}")
-            reserveSlotFailedWorkers.add(workerInfo)
-          }
+          logError(s"[reserveSlots] Failed to" +
+            s" reserve buffers for ${Utils.makeShuffleKey(applicationId, shuffleId)}" +
+            s" from worker ${workerInfo.readableAddress()}. Reason: ${res.reason}")
+          reserveSlotFailedWorkers.add(workerInfo)
         }
     }
 


### PR DESCRIPTION
…-pang situation

```
22/08/22 20:03:39 INFO LifecycleManager: Try reserve slots for application_1660226621060_0180-549 for 1 times.
22/08/22 20:03:39 WARN LifecycleManager: [reserve buffer] failed due to blacklist:
Host: 192.168.15.9
RpcPort: 37761
PushPort: 37903
FetchPort: 37517
ReplicatePort: 38449
SlotsUsed: 0()
LastHeartBeat: 0
Disks: {}
WorkerRef: NettyRpcEndpointRef(rss://WorkerEndpoint@192.168.15.9:37761)

22/08/22 20:03:41 INFO LifecycleManager: Received Blacklist from Master, blacklist: [] unkown workers: []
22/08/22 20:03:50 INFO LifecycleManager: Report Worker Failure: Buffer(
Host: 192.168.15.9
RpcPort: 37761
PushPort: 37903
FetchPort: 37517
ReplicatePort: 38449
SlotsUsed: 0()
LastHeartBeat: 0
Disks: {}
WorkerRef: NettyRpcEndpointRef(rss://WorkerEndpoint@192.168.15.9:37761)
)
```

# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
close #428 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
