### PR TITLE
Improve MemoryTracker log format and change it's thread to daemon

### DIFF
--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
+import com.aliyun.emr.rss.common.network.util.ByteUnit;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.util.internal.PlatformDependent;
 import org.slf4j.Logger;
@@ -160,25 +161,21 @@ public class MemoryTracker {
       }
     }, checkInterval, checkInterval, TimeUnit.MILLISECONDS);
 
-    reportService.scheduleWithFixedDelay(() -> logger.info("Track all direct memory usage :{}/{}," +
-        "disk buffer size:{}, sort memory size : {}",
+    reportService.scheduleWithFixedDelay(() -> logger.info(
+            "Direct memory usage: {}/{}MB, disk buffer size: {}MB, sort memory size: {}MB",
         toMb(nettyMemoryCounter.get()), toMb(maxDirectorMemory),
         toMb(diskBufferCounter.get()), toMb(sortMemoryCounter.get())),
       reportInterval, reportInterval, TimeUnit.SECONDS);
 
-    logger.info("Memory tracker initialized with :  " +
-                  "\n max direct memory : {} ({} MB)" +
-                  "\n pause pushdata memory : {} ({} MB)" +
-                  "\n pause replication memory : {} ({} MB)" +
-                  "\n resume memory : {} ({} MB)",
-      maxDirectorMemory, toMb(maxDirectorMemory),
-      pausePushDataThreshold, toMb(pausePushDataThreshold),
-      pauseReplicateThreshold, toMb(pauseReplicateThreshold),
-      resumeThreshold, toMb(resumeThreshold));
+    logger.info("Memory tracker initialized with: " +
+                "max direct memory: {}MB, pause pushdata memory: {}MB, " +
+                "pause replication memory: {}MB, resume memory: {}MB",
+            toMb(maxDirectorMemory), toMb(pausePushDataThreshold),
+            toMb(pauseReplicateThreshold), toMb(resumeThreshold));
   }
 
-  private double toMb(long bytes) {
-    return bytes / 1024.0 / 1024.0;
+  private long toMb(long bytes) {
+    return ByteUnit.BYTE.toMiB(bytes);
   }
 
   private void initDirectMemoryIndicator() {

--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
@@ -28,13 +28,13 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.LongAdder;
 
-import com.aliyun.emr.rss.common.network.util.ByteUnit;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.netty.util.internal.PlatformDependent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sun.misc.VM;
 
+import com.aliyun.emr.rss.common.network.util.ByteUnit;
 import com.aliyun.emr.rss.common.protocol.TransportModuleConstants;
 
 public class MemoryTracker {

--- a/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/server/MemoryTracker.java
@@ -49,13 +49,13 @@ public class MemoryTracker {
 
   private final ScheduledExecutorService checkService = Executors
     .newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-      .setNameFormat("MemoryTracker-check-thread").build());
+      .setNameFormat("MemoryTracker-check-thread").setDaemon(true).build());
   private final ScheduledExecutorService reportService = Executors
     .newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-      .setNameFormat("MemoryTracker-report-thread").build());
+      .setNameFormat("MemoryTracker-report-thread").setDaemon(true).build());
   private final ExecutorService actionService = Executors
     .newSingleThreadScheduledExecutor(new ThreadFactoryBuilder()
-      .setNameFormat("MemoryTracker-action-thread").build());
+      .setNameFormat("MemoryTracker-action-thread").setDaemon(true).build());
 
   private AtomicLong nettyMemoryCounter = null;
   private final AtomicLong sortMemoryCounter = new AtomicLong(0);
@@ -64,7 +64,7 @@ public class MemoryTracker {
   private final LongAdder pausePushDataAndReplicateCounter = new LongAdder();
   private MemoryTrackerStat memoryTrackerStat = MemoryTrackerStat.resumeAll;
   private boolean underPressure;
-  private AtomicBoolean trimInProcess = new AtomicBoolean(false);
+  private final AtomicBoolean trimInProcess = new AtomicBoolean(false);
 
   public static MemoryTracker initialize(
     double pausePushDataRatio,

--- a/common/src/main/java/com/aliyun/emr/rss/common/network/util/ByteUnit.java
+++ b/common/src/main/java/com/aliyun/emr/rss/common/network/util/ByteUnit.java
@@ -51,7 +51,7 @@ public enum ByteUnit {
     }
   }
 
-  public double toBytes(long d) {
+  public long toBytes(long d) {
     if (d < 0) {
       throw new IllegalArgumentException("Negative size value. Size must be positive: " + d);
     }


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Improve MemoryTracker log format and change it's thread to daemon

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
the current format looks not friendly.
```
22/08/27 20:33:09 INFO MemoryTracker: Track all direct memory usage :1928.0/4096.0,disk buffer size:1.2319183349609375, sort memory size : 0.0
22/08/27 20:33:19 INFO MemoryTracker: Track all direct memory usage :1928.0/4096.0,disk buffer size:1.2319183349609375, sort memory size : 0.0
22/08/27 20:33:29 INFO MemoryTracker: Track all direct memory usage :1928.0/4096.0,disk buffer size:1.2319183349609375, sort memory size : 0.0
```
A monitor thread should be a daemon, otherwise, it may block shutdown.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
