### PR TITLE
[ISSUE-465][Bug] Common module scalatest style unit test don't actually run

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -154,6 +154,15 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <configuration>
+          <parallel>false</parallel>
+          <forkMode>once</forkMode>
+          <argLine>-Xmx2048m</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>${maven.plugin.protobuf.version}</version>

--- a/common/src/test/scala/com/aliyun/emr/rss/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/com/aliyun/emr/rss/common/meta/WorkerInfoSuite.scala
@@ -149,6 +149,6 @@ class WorkerInfoSuite extends RssFunSuite {
   test("WorkerInfo equals when numSlots different.") {
     val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 2000, null, null)
-    assertEquals(worker1, worker2)
+    assertNotEquals(worker1, worker2)
   }
 }

--- a/server-master/pom.xml
+++ b/server-master/pom.xml
@@ -114,6 +114,11 @@
             <plugin>
                 <groupId>org.scalatest</groupId>
                 <artifactId>scalatest-maven-plugin</artifactId>
+                <configuration>
+                    <parallel>false</parallel>
+                    <forkMode>once</forkMode>
+                    <argLine>-Xmx2048m</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add scalatest-maven-plugin in common's module pom.
 
![image](https://user-images.githubusercontent.com/30563796/187036619-f644918b-c8ba-478e-8c45-a58677d4b7e2.png)
![image](https://user-images.githubusercontent.com/30563796/187037483-8a61ae18-677f-49eb-9570-6d8f851b8e3e.png)


### Why are the changes needed?
These 3 unit tests which use scalatest not be launched in pipeline when using maven test.
WorkerInfoSuite, RssConfSuite, UtilsSuite

### What are the items that need reviewer attention?
Should we use the same configs of `scalatest-maven-plugin` for all module's pom which has this plugin in <extensions> ? Current new added config is copied from worker module's pom. And should we add this plugin in advance for other modules which have scala unit test only in the Junit style? Such as client-spark/shuffle-manager-2/3.

### Related issues.
#465 

### Related pull requests.


### How was this patch tested?
unit tests

/cc @related-reviewer

/assign @main-reviewer
