### PR TITLE
Fix NPE caused by SlotsAllocator returns null

### DIFF
--- a/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/SlotsAllocator.java
+++ b/server-master/src/main/java/com/aliyun/emr/rss/service/deploy/master/SlotsAllocator.java
@@ -56,7 +56,7 @@ public class SlotsAllocator {
       return new HashMap<>();
     }
     if (workers.size() < 2 && shouldReplicate) {
-      return null;
+      return new HashMap<>();
     }
     Map<WorkerInfo, Tuple2<List<PartitionLocation>, List<PartitionLocation>>> slots =
         new HashMap<>();
@@ -96,7 +96,7 @@ public class SlotsAllocator {
       return new HashMap<>();
     }
     if (workers.size() < 2 && shouldReplicate) {
-      return null;
+      return new HashMap<>();
     }
 
     List<DiskInfo> usableDisks = new ArrayList<>();

--- a/server-master/src/test/java/com/aliyun/emr/rss/service/deploy/master/SlotsAllocatorSuiteJ.java
+++ b/server-master/src/test/java/com/aliyun/emr/rss/service/deploy/master/SlotsAllocatorSuiteJ.java
@@ -226,7 +226,7 @@ public class SlotsAllocatorSuiteJ {
       if (shouldReplicate) {
         slots.forEach((k, v) -> {
           Set<String> locationDuplicationSet = new HashSet<>();
-          v._1.stream().forEach(i -> {
+          v._1.forEach(i -> {
             String uniqueId = i.getUniqueId();
             assert !locationDuplicationSet.contains(uniqueId);
             locationDuplicationSet.add(uniqueId);
@@ -256,7 +256,7 @@ public class SlotsAllocatorSuiteJ {
         Assert.assertEquals(partitionIds.size(), usedTotalSlots);
       }
     } else {
-      assert null == slots :
+      assert slots.isEmpty() :
         "Expect to fail to offer slots, but return " + slots.size() + " slots.";
     }
   }


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

When `workers.size() < 2 && shouldReplicate`, `SlotsAllocator#offerSlotsRoundRobin` and `SlotsAllocator#offerSlotsLoadAware` should return empty Map instead of `null`.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix NPE

```
22/08/28 00:48:55 ERROR Inbox: Ignoring error
java.lang.NullPointerException
	at com.aliyun.emr.rss.service.deploy.master.SlotsAllocator.slotsToDiskAllocations(SlotsAllocator.java:388)
	at com.aliyun.emr.rss.service.deploy.master.Master.handleRequestSlots(Master.scala:412)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$10(Master.scala:194)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at com.aliyun.emr.rss.service.deploy.master.Master.executeWithLeaderChecker(Master.scala:167)
	at com.aliyun.emr.rss.service.deploy.master.Master$$anonfun$receiveAndReply$1.applyOrElse(Master.scala:194)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
	at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
	at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
```

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
