### PR TITLE
[ISSUE-489][FEATURE] Implement more info for master and worker

### DIFF
--- a/server-master/pom.xml
+++ b/server-master/pom.xml
@@ -58,15 +58,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-library</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-reflect</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/server-master/pom.xml
+++ b/server-master/pom.xml
@@ -58,6 +58,15 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -569,7 +569,15 @@ private[deploy] class Master(
   }
 
   def getHostnameList: String = {
-    statusSystem.hostnameSet.asScala.mkString(",")
+    statusSystem.hostnameSet.asScala.mkString("\n")
+  }
+
+  def getApplicationList: String = {
+    statusSystem.appHeartbeatTime.keys().asScala.mkString("\n")
+  }
+
+  def getShuffleList: String = {
+    statusSystem.registeredShuffle.asScala.mkString("\n")
   }
 
   private def requestGetWorkerInfos(endpoint: RpcEndpointRef): GetWorkerInfosResponse = {

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/http/HttpRequestHandler.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/http/HttpRequestHandler.scala
@@ -28,8 +28,9 @@ import com.aliyun.emr.rss.common.metrics.sink.PrometheusHttpRequestHandler
 import com.aliyun.emr.rss.service.deploy.master.Master
 
 @Sharable
-class HttpRequestHandler(val master: Master,
-                         prometheusHttpRequestHandler: PrometheusHttpRequestHandler)
+class HttpRequestHandler(
+    val master: Master,
+    prometheusHttpRequestHandler: PrometheusHttpRequestHandler)
   extends SimpleChannelInboundHandler[FullHttpRequest] with Logging{
 
   private val INVALID = "invalid"
@@ -68,6 +69,10 @@ class HttpRequestHandler(val master: Master,
         master.getThreadDump
       case "/hostnames" =>
         master.getHostnameList
+      case "/applications" =>
+        master.getApplicationList
+      case "/shuffles" =>
+        master.getShuffleList
       case _ => INVALID
     }
   }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
@@ -250,7 +250,7 @@ private[deploy] class Worker(
         try {
           val httpServer = new HttpServer(
             new HttpServerInitializer(
-              new HttpRequestHandler(metricsSystem.getPrometheusHandler)), port)
+              new HttpRequestHandler(this, metricsSystem.getPrometheusHandler)), port)
           httpServer.start()
           initialized = true
         } catch {
@@ -360,6 +360,10 @@ private[deploy] class Worker(
     }
     partitionsSorter.cleanup(expiredShuffleKeys)
     storageManager.cleanupExpiredShuffleKey(expiredShuffleKeys)
+  }
+
+  def getShuffleList: String = {
+    storageManager.shuffleKeySet().asScala.mkString("\n")
   }
 
   def isRegistered(): Boolean = {

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/http/HttpRequestHandler.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/http/HttpRequestHandler.scala
@@ -22,12 +22,15 @@ import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext, SimpleCha
 import io.netty.channel.ChannelHandler.Sharable
 import io.netty.handler.codec.http._
 import io.netty.util.CharsetUtil
-
 import com.aliyun.emr.rss.common.internal.Logging
 import com.aliyun.emr.rss.common.metrics.sink.PrometheusHttpRequestHandler
+import com.aliyun.emr.rss.common.util.Utils
+import com.aliyun.emr.rss.service.deploy.worker.Worker
 
 @Sharable
-class HttpRequestHandler(prometheusHttpRequestHandler: PrometheusHttpRequestHandler)
+class HttpRequestHandler(
+    worker: Worker,
+    prometheusHttpRequestHandler: PrometheusHttpRequestHandler)
   extends SimpleChannelInboundHandler[FullHttpRequest] with Logging{
 
   private val INVALID = "invalid"
@@ -38,14 +41,35 @@ class HttpRequestHandler(prometheusHttpRequestHandler: PrometheusHttpRequestHand
 
   override def channelRead0(ctx: ChannelHandlerContext, req: FullHttpRequest): Unit = {
     val uri = req.uri()
-    val msg = prometheusHttpRequestHandler.handleRequest(uri)
+    val msg = handleRequest(uri)
+    val response = msg match {
+      case INVALID =>
+        if (prometheusHttpRequestHandler != null) {
+          prometheusHttpRequestHandler.handleRequest(uri)
+        } else {
+          s"invalid uri ${uri}"
+        }
+      case _ => msg
+    }
 
     val res = new DefaultFullHttpResponse(
       HttpVersion.HTTP_1_1,
       HttpResponseStatus.OK,
-      Unpooled.copiedBuffer(msg, CharsetUtil.UTF_8)
+      Unpooled.copiedBuffer(response, CharsetUtil.UTF_8)
     )
     res.headers().set(HttpHeaderNames.CONTENT_TYPE, "text/html; charset=UTF-8");
     ctx.writeAndFlush(res).addListener(ChannelFutureListener.CLOSE);
+  }
+
+  def handleRequest(uri: String): String = {
+    uri match {
+      case "/workerInfo" =>
+        worker.workerInfo.toString()
+      case "/threadDump" =>
+        Utils.getThreadDump()
+      case "/shuffles" =>
+        worker.getShuffleList
+      case _ => INVALID
+    }
   }
 }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/http/HttpRequestHandler.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/http/HttpRequestHandler.scala
@@ -22,6 +22,7 @@ import io.netty.channel.{ChannelFutureListener, ChannelHandlerContext, SimpleCha
 import io.netty.channel.ChannelHandler.Sharable
 import io.netty.handler.codec.http._
 import io.netty.util.CharsetUtil
+
 import com.aliyun.emr.rss.common.internal.Logging
 import com.aliyun.emr.rss.common.metrics.sink.PrometheusHttpRequestHandler
 import com.aliyun.emr.rss.common.util.Utils


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement more info for admin to directly know cluster's status

Master
```
(base) [root@ip-xx-xx-xx-xx ~]# curl localhost:9098/applications
application_1661229435673_1827267(base) 


[root@ip-xx-xx-xx-xx ~]# curl localhost:9098/shuffles
application_1661229435673_1827267-0(base)
```
Worker
```
[root@ip-xx-xx-xx-xx ~]# curl localhost:9096/workerInfo

Host: xx-xx-xx-xx
RpcPort: 37699
PushPort: 11114
FetchPort: 11113
ReplicatePort: 11115
TotalSlots: 40000
SlotsUsed: 15
SlotsAvailable: 39985
LastHeartBeat: 0
WorkerRef: null


[root@ip-xx-xx-xx-xx ~]# curl localhost:9096/shuffles
application_1661229435673_1827267-0
application_1661229435673_1827267-2
application_1661229435673_1827267-1
```

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
https://github.com/alibaba/RemoteShuffleService/issues/489

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
