### PR TITLE
Recover maven property rss.shuffle.manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -662,10 +662,11 @@
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.5</spark.version>
+        <rss.shuffle.manager>shuffle-manager-2</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-2</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -689,10 +690,11 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.1</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -716,10 +718,11 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -743,10 +746,11 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.2</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -770,10 +774,11 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.0</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Recover maven property `rss.shuffle.manager`

### Why are the changes needed?


It was removed in https://github.com/alibaba/RemoteShuffleService/pull/497, but `make-distribution.sh` depends on this property to find the client jar folder.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
