### PR TITLE
[BUG]Fix slots release when cleanup expired shuffle

### DIFF
--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/Worker.scala
@@ -381,6 +381,7 @@ private[deploy] class Worker(
       partitionLocationInfo.removeMasterPartitions(shuffleKey)
       partitionLocationInfo.removeSlavePartitions(shuffleKey)
       shuffleMapperAttempts.remove(shuffleKey)
+      workerInfo.releaseSlots(shuffleKey)
       logInfo(s"Cleaned up expired shuffle $shuffleKey")
     }
     partitionsSorter.cleanup(expiredShuffleKeys)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added `releaseSlots` in `Worker.cleanup`

### Why are the changes needed?
Slots should be released when workers cleaning expired shuffle, otherwise `WorkerInfo` will be incorrect.

assign @waitinfuture 