### PR TITLE
[ISSUE-498][FEATURE] Worker should clean shuffle data if not enable graceful shutdown

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -923,6 +923,14 @@ object RssConf extends Logging {
     conf.getTimeAsMs("rss.worker.partitionSorterCloseAwaitTime", "120s")
   }
 
+  def waitCleanTaskSubmitBeforeCloseTimeoutMs(conf: RssConf): Long = {
+    conf.getTimeAsMs("rss.worker.waitCleanTaskSubmitTimeoutMs", "500ms")
+  }
+
+  def workerDiskFlusherShutdownTimeoutMs(conf: RssConf): Long = {
+    conf.getTimeAsMs("rss.worker.diskFlusherShutdownTimeoutMs", "3000ms")
+  }
+
   def offerSlotsAlgorithm(conf: RssConf): String = {
     var algorithm = conf.get("rss.offer.slots.algorithm", "roundrobin")
     if (algorithm != "loadaware" && algorithm != "roundrobin") {
@@ -943,7 +951,7 @@ object RssConf extends Logging {
 
   def hdfsDir(conf: RssConf): String = {
     val hdfsDir = conf.get("rss.worker.hdfs.dir", "")
-    if (hdfsDir.nonEmpty && Utils.isHdfsPath(hdfsDir)) {
+    if (hdfsDir.nonEmpty && !Utils.isHdfsPath(hdfsDir)) {
       log.error(s"rss.worker.hdfs.dir configuration is wrong $hdfsDir. Disable hdfs support.")
       ""
     } else {

--- a/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/RssConf.scala
@@ -923,10 +923,6 @@ object RssConf extends Logging {
     conf.getTimeAsMs("rss.worker.partitionSorterCloseAwaitTime", "120s")
   }
 
-  def waitCleanTaskSubmitBeforeCloseTimeoutMs(conf: RssConf): Long = {
-    conf.getTimeAsMs("rss.worker.waitCleanTaskSubmitTimeoutMs", "500ms")
-  }
-
   def workerDiskFlusherShutdownTimeoutMs(conf: RssConf): Long = {
     conf.getTimeAsMs("rss.worker.diskFlusherShutdownTimeoutMs", "3000ms")
   }

--- a/common/src/test/scala/com/aliyun/emr/rss/common/meta/WorkerInfoSuite.scala
+++ b/common/src/test/scala/com/aliyun/emr/rss/common/meta/WorkerInfoSuite.scala
@@ -151,7 +151,7 @@ class WorkerInfoSuite extends RssFunSuite {
     assertNotEquals(worker1, worker2)
   }
 
-  test("WorkerInfo equals when numSlots different.") {
+  test("WorkerInfo not equals when replicate port different.") {
     val worker1 = new WorkerInfo("h1", 10001, 10002, 10003, 1000, null, null)
     val worker2 = new WorkerInfo("h1", 10001, 10002, 10003, 2000, null, null)
     assertNotEquals(worker1, worker2)

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
@@ -449,8 +449,13 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
     }
     if (null != diskOperators) {
       cleanupExpiredShuffleKey(shuffleKeySet())
-      ThreadUtils.parmap(diskOperators.asScala.toMap, "ShutdownDiskOperators", diskOperators.size()) { entry =>
-        ThreadUtils.shutdown(entry._2, RssConf.workerDiskFlusherShutdownTimeoutMs(conf).milliseconds)
+      ThreadUtils.parmap(
+        diskOperators.asScala.toMap,
+        "ShutdownDiskOperators",
+        diskOperators.size()) { entry =>
+        ThreadUtils.shutdown(
+          entry._2,
+          RssConf.workerDiskFlusherShutdownTimeoutMs(conf).milliseconds)
       }
     }
     storageScheduler.shutdownNow()


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Worker would clean shuffle data before close if it doesn't enable `rss.worker.graceful.shutdown`
2. Modify RssConf.hdfsDir() logic
3. Modify a wrong unit test name

After adding clean logic
![image](https://user-images.githubusercontent.com/30563796/188181965-29e3de61-0dd5-4648-bf32-4e5f9a9ff0c3.png)

### Why are the changes needed?
As mentioned in #498 ,  if we set `rss.disk.minimum.reserve.size` as a big value like 500GB, and shutdown the worker during handling shuffle without enabling `rss.worker.graceful.shutdown`, it will leave the shuffle data there. Let's assume the rest shuffle data is huge data and it make the free space be less than 500GB, then it would trigger the DeviceMonitor's check alert and put worker into blacklist when restart worker.

### What are the items that need reviewer attention?
1. do we need to leave a time period which is in code to wait for worker to submit all delete file task into threadpool before threadpool shutdown? and do these 2 timeout's default value need to be shrink?
2. The change of RSS.hdfsDir(), i'm worried about if i misunderstand it.

### Related issues.
#498 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
