### PR TITLE
Use different artifact name for shuffle manager 2/3

### DIFF
--- a/client-spark/shuffle-manager-2/pom.xml
+++ b/client-spark/shuffle-manager-2/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>rss-shuffle-manager-2</artifactId>
+    <artifactId>shuffle-manager-2</artifactId>
     <packaging>jar</packaging>
     <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 2</name>
 

--- a/client-spark/shuffle-manager-2/pom.xml
+++ b/client-spark/shuffle-manager-2/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>rss-shuffle-manager</artifactId>
+    <artifactId>rss-shuffle-manager-2</artifactId>
     <packaging>jar</packaging>
     <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 2</name>
 

--- a/client-spark/shuffle-manager-3/pom.xml
+++ b/client-spark/shuffle-manager-3/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>rss-shuffle-manager</artifactId>
+    <artifactId>rss-shuffle-manager-3</artifactId>
     <packaging>jar</packaging>
     <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 3</name>
 

--- a/client-spark/shuffle-manager-3/pom.xml
+++ b/client-spark/shuffle-manager-3/pom.xml
@@ -25,7 +25,7 @@
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
-    <artifactId>rss-shuffle-manager-3</artifactId>
+    <artifactId>shuffle-manager-3</artifactId>
     <packaging>jar</packaging>
     <name>Aliyun E-MapReduce Shuffle Service Shuffle Manager for Spark 3</name>
 

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -106,10 +106,12 @@ SCALA_VERSION=$("$MVN" help:evaluate -Dexpression=scala.binary.version $@ 2>/dev
     | grep -v "INFO"\
     | grep -v "WARNING"\
     | tail -n 1)
-SHUFFLE_MANAGER_DIR=$("$MVN" help:evaluate -Dexpression=rss.shuffle.manager $@ 2>/dev/null\
+SPARK_VERSION=$("$MVN" help:evaluate -Dexpression=spark.version $@ 2>/dev/null\
     | grep -v "INFO"\
     | grep -v "WARNING"\
     | tail -n 1)
+
+SPARK_MAJOR_VERSION=${SPARK_VERSION%%.*}
 
 echo "RSS version is $VERSION"
 
@@ -145,11 +147,11 @@ echo "RSS $VERSION$GITREVSTRING" > "$DISTDIR/RELEASE"
 echo "Build flags: $@" >> "$DISTDIR/RELEASE"
 
 # Copy jars
-cp "$RSS_HOME"/server-master/target/master-"$VERSION".jar "$DISTDIR/master-jars/"
-cp "$RSS_HOME"/server-master/target/scala-${SCALA_VERSION}/jars/*.jar "$DISTDIR/master-jars/"
-cp "$RSS_HOME"/server-worker/target/worker-"$VERSION".jar "$DISTDIR/worker-jars/"
-cp "$RSS_HOME"/server-worker/target/scala-${SCALA_VERSION}/jars/*.jar "$DISTDIR/worker-jars/"
-cp "$RSS_HOME"/client-spark/${SHUFFLE_MANAGER_DIR}/target/rss-shuffle-manager-"$VERSION"-shaded.jar "$DISTDIR/spark/"
+cp "$RSS_HOME"/server-master/target/master-$VERSION.jar "$DISTDIR/master-jars/"
+cp "$RSS_HOME"/server-master/target/scala-$SCALA_VERSION/jars/*.jar "$DISTDIR/master-jars/"
+cp "$RSS_HOME"/server-worker/target/worker-$VERSION.jar "$DISTDIR/worker-jars/"
+cp "$RSS_HOME"/server-worker/target/scala-$SCALA_VERSION/jars/*.jar "$DISTDIR/worker-jars/"
+cp "$RSS_HOME"/client-spark/shuffle-manager-$SPARK_MAJOR_VERSION/target/rss-shuffle-manager-$SPARK_MAJOR_VERSION-$VERSION-shaded.jar "$DISTDIR/spark/"
 
 # Copy other things
 mkdir "$DISTDIR/conf"

--- a/dev/make-distribution.sh
+++ b/dev/make-distribution.sh
@@ -151,7 +151,7 @@ cp "$RSS_HOME"/server-master/target/master-$VERSION.jar "$DISTDIR/master-jars/"
 cp "$RSS_HOME"/server-master/target/scala-$SCALA_VERSION/jars/*.jar "$DISTDIR/master-jars/"
 cp "$RSS_HOME"/server-worker/target/worker-$VERSION.jar "$DISTDIR/worker-jars/"
 cp "$RSS_HOME"/server-worker/target/scala-$SCALA_VERSION/jars/*.jar "$DISTDIR/worker-jars/"
-cp "$RSS_HOME"/client-spark/shuffle-manager-$SPARK_MAJOR_VERSION/target/rss-shuffle-manager-$SPARK_MAJOR_VERSION-$VERSION-shaded.jar "$DISTDIR/spark/"
+cp "$RSS_HOME"/client-spark/shuffle-manager-$SPARK_MAJOR_VERSION/target/shuffle-manager-$SPARK_MAJOR_VERSION-$VERSION-shaded.jar "$DISTDIR/spark/"
 
 # Copy other things
 mkdir "$DISTDIR/conf"

--- a/pom.xml
+++ b/pom.xml
@@ -662,11 +662,10 @@
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.5</spark.version>
-        <rss.shuffle.manager>shuffle-manager-2</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/${rss.shuffle.manager}</module>
+        <module>client-spark/shuffle-manager-2</module>
       </modules>
       <dependencies>
         <dependency>
@@ -690,11 +689,10 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.1</spark.version>
-        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/${rss.shuffle.manager}</module>
+        <module>client-spark/shuffle-manager-3</module>
       </modules>
       <dependencies>
         <dependency>
@@ -718,11 +716,10 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
-        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/${rss.shuffle.manager}</module>
+        <module>client-spark/shuffle-manager-3</module>
       </modules>
       <dependencies>
         <dependency>
@@ -746,11 +743,10 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.2</spark.version>
-        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/${rss.shuffle.manager}</module>
+        <module>client-spark/shuffle-manager-3</module>
       </modules>
       <dependencies>
         <dependency>
@@ -774,11 +770,10 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.0</spark.version>
-        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/${rss.shuffle.manager}</module>
+        <module>client-spark/shuffle-manager-3</module>
       </modules>
       <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -662,10 +662,11 @@
         <scala.version>2.11.12</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
         <spark.version>2.4.5</spark.version>
+        <rss.shuffle.manager>shuffle-manager-2</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-2</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -689,10 +690,11 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.0.1</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -716,10 +718,11 @@
         <scala.version>2.12.10</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.1.3</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -743,10 +746,11 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.2.2</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>
@@ -770,10 +774,11 @@
         <scala.version>2.12.15</scala.version>
         <scala.binary.version>2.12</scala.binary.version>
         <spark.version>3.3.0</spark.version>
+        <rss.shuffle.manager>shuffle-manager-3</rss.shuffle.manager>
       </properties>
       <modules>
         <module>client-spark/shuffle-manager-common</module>
-        <module>client-spark/shuffle-manager-3</module>
+        <module>client-spark/${rss.shuffle.manager}</module>
       </modules>
       <dependencies>
         <dependency>

--- a/server-worker/pom.xml
+++ b/server-worker/pom.xml
@@ -85,7 +85,7 @@
         </dependency>
         <dependency>
             <groupId>com.aliyun.emr</groupId>
-            <artifactId>rss-shuffle-manager</artifactId>
+            <artifactId>${rss.shuffle.manager}</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
# [BUG]/[FEATURE] title

### What changes were proposed in this pull request?

Use different artifact names for shuffle manager 2/3

### Why are the changes needed?

Duplicated module name may cause some issues for Maven command, e.g. 

```
build/mvn versions:set -DnewVersion=0.2.0-netease -DgenerateBackupPoms=false -Pspark-3.1
```
the bump version command does not work well before, but does after this change.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?

```
dev/make-distribution.sh -Pspark-2.4
```

```
dev/make-distribution.sh -Pspark-3.1
```

```
build/mvn versions:set -DnewVersion=0.2.0-netease -DgenerateBackupPoms=false -Pspark-3.1
```


/cc @related-reviewer

/assign @main-reviewer
