### PR TITLE
[ISSUE-551][BUG] CompressionMethod and checksum are not consistent when zstd level is negative

### DIFF
--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
@@ -24,15 +24,12 @@ import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
 
 public class RssLz4Compressor extends RssLz4Trait implements Compressor {
-  private final int compressionLevel;
   private final LZ4Compressor compressor;
   private final Checksum checksum;
   private byte[] compressedBuffer;
   private int compressedTotalSize;
 
   public RssLz4Compressor(int blockSize) {
-    int level = 32 - Integer.numberOfLeadingZeros(blockSize - 1) - COMPRESSION_LEVEL_BASE;
-    this.compressionLevel = Math.max(0, level);
     this.compressor = LZ4Factory.fastestInstance().fastCompressor();
     checksum = XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum();
     initCompressBuffer(blockSize);
@@ -65,7 +62,7 @@ public class RssLz4Compressor extends RssLz4Trait implements Compressor {
       compressMethod = COMPRESSION_METHOD_LZ4;
     }
 
-    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+    compressedBuffer[MAGIC_LENGTH] = (byte) compressMethod;
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);
     writeIntLE(check, compressedBuffer, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Decompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Decompressor.java
@@ -42,8 +42,7 @@ public class RssLz4Decompressor extends RssLz4Trait implements Decompressor {
 
   @Override
   public int decompress(byte[] src, byte[] dst, int dstOff) {
-    int token = src[MAGIC_LENGTH] & 0xFF;
-    int compressionMethod = token & 0xF0;
+    int compressionMethod = src[MAGIC_LENGTH] & 0xFF;
     int compressedLen = readIntLE(src, MAGIC_LENGTH + 1);
     int originalLen = readIntLE(src, MAGIC_LENGTH + 5);
     int check = readIntLE(src, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Trait.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Trait.java
@@ -23,7 +23,7 @@ public abstract class RssLz4Trait {
 
   public static final int HEADER_LENGTH =
       MAGIC_LENGTH // magic bytes
-          + 1 // token
+          + 1 // compress method
           + 4 // compressed length
           + 4 // decompressed length
           + 4; // checksum

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
@@ -69,9 +69,7 @@ public class RssZstdCompressor extends RssZstdTrait implements Compressor {
       compressMethod = COMPRESSION_METHOD_ZSTD;
     }
 
-    int level = compressionLevel < 0 ? (Math.abs(compressionLevel) + 22) : compressionLevel;
-    assert (0 <= level && level <= 27);
-    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | level);
+    compressedBuffer[MAGIC_LENGTH] = (byte) compressMethod;
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);
     writeIntLE(check, compressedBuffer, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
@@ -69,6 +69,8 @@ public class RssZstdCompressor extends RssZstdTrait implements Compressor {
       compressMethod = COMPRESSION_METHOD_ZSTD;
     }
 
+    int level = compressionLevel < 0 ? (Math.abs(compressionLevel) + 22) : compressionLevel;
+    assert (0 <= level && level <= 27);
     compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
@@ -71,7 +71,7 @@ public class RssZstdCompressor extends RssZstdTrait implements Compressor {
 
     int level = compressionLevel < 0 ? (Math.abs(compressionLevel) + 22) : compressionLevel;
     assert (0 <= level && level <= 27);
-    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | level);
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);
     writeIntLE(check, compressedBuffer, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
@@ -59,6 +59,10 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
               "Original length corrupted! expected: {}, actual: {}.", originalLen, originalLen2);
           return -1;
         }
+        break;
+      default:
+        logger.error("Unknown compression method which is {} and the token is {}.", compressionMethod, token);
+        return -1;
     }
 
     checksum.reset();

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
@@ -39,10 +39,9 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
 
   @Override
   public int decompress(byte[] src, byte[] dst, int dstOff) {
-    int token = src[MAGIC_LENGTH] & 0xFF;
-    int compressionMethod = token & 0xF0;
+    int compressionMethod = src[MAGIC_LENGTH] & 0xFF;
     int compressedLen = readIntLE(src, MAGIC_LENGTH + 1);
-    int originalLen = getOriginalLen(src);
+    int originalLen = readIntLE(src, MAGIC_LENGTH + 5);
     int check = readIntLE(src, MAGIC_LENGTH + 9);
 
     switch (compressionMethod) {
@@ -61,10 +60,7 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
         }
         break;
       default:
-        logger.error(
-            "Unknown compression method which is {} and the token is {}.",
-            compressionMethod,
-            token);
+        logger.error("Unknown compression method whose decimal number is {} .", compressionMethod);
         return -1;
     }
 

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
@@ -61,7 +61,10 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
         }
         break;
       default:
-        logger.error("Unknown compression method which is {} and the token is {}.", compressionMethod, token);
+        logger.error(
+            "Unknown compression method which is {} and the token is {}.",
+            compressionMethod,
+            token);
         return -1;
     }
 

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdTrait.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdTrait.java
@@ -23,7 +23,7 @@ public abstract class RssZstdTrait {
 
   public static final int HEADER_LENGTH =
       MAGIC_LENGTH // magic bytes
-          + 1 // token
+          + 1 // compress method
           + 4 // compressed length
           + 4 // decompressed length
           + 4; // checksum


### PR DESCRIPTION
### What changes were proposed in this pull request?
negative level will be transformed to a unique positive number, and add a default case for RssZstdDecompressor for better debug.

### Why are the changes needed?
When zstd level is negative, it will compute a wrong token inside data head of buffer, because the negative number's complementary code(e.g: -1 is 1111 1111) can't meet the requirement that store the compressMethod and level info into one byte by bit operation. 
```
compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
``` 
And when decompressor decompresses the data, it will get a wrong compress method from the wrong token, then it will skip the switch cases and directly using the given dst array to calculate the checksum, then finally get a wrong checksum.
```
switch (compressionMethod) {
      case COMPRESSION_METHOD_RAW:
        System.arraycopy(src, HEADER_LENGTH, dst, dstOff, originalLen);
        break;
      case COMPRESSION_METHOD_ZSTD:
        int originalLen2 =
            (int)
                Zstd.decompressByteArray(
                    dst, dstOff, originalLen, src, HEADER_LENGTH, compressedLen);
        if (originalLen != originalLen2) {
          logger.error(
              "Original length corrupted! expected: {}, actual: {}.", originalLen, originalLen2);
          return -1;
        }
}
```

In RssLz4Compressor, there isn't such as issue, because the minimum level will be 0.
```
this.compressionLevel = Math.max(0, level);
```
### What are the items that need reviewer attention?


### Related issues.
#551 

### Related pull requests.
#451 

### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
