### PR TITLE
[ISSUE-584][REFACTOR] Create FileWriter failed should show clear pathan mount point to help debug

### DIFF
--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
@@ -323,8 +323,10 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
           return fileWriter
         } catch {
           case t: Throwable =>
-            logError(s"Create FileWriter in path $file of mount $mountPoint failed, " +
-              s"report to DeviceMonitor", t)
+            logError(
+              s"Create FileWriter in path $file of mount $mountPoint failed, " +
+                s"report to DeviceMonitor",
+              t)
             exception = new IOException(t)
             deviceMonitor.reportDeviceError(mountPoint, exception, DiskStatus.ReadOrWriteFailure)
         }

--- a/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
+++ b/server-worker/src/main/scala/com/aliyun/emr/rss/service/deploy/worker/storage/StorageManager.scala
@@ -323,7 +323,8 @@ final private[worker] class StorageManager(conf: RssConf, workerSource: Abstract
           return fileWriter
         } catch {
           case t: Throwable =>
-            logError("Create Writer failed, report to DeviceMonitor", t)
+            logError(s"Create FileWriter in path $file of mount $mountPoint failed, " +
+              s"report to DeviceMonitor", t)
             exception = new IOException(t)
             deviceMonitor.reportDeviceError(mountPoint, exception, DiskStatus.ReadOrWriteFailure)
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
```

22/09/09 13:01:50,532 ERROR [dispatcher-event-loop-19] LocalStorageManager: Create Writer failed, report to DeviceMonitor
java.io.IOException: Permission denied
        at java.io.UnixFileSystem.createFileExclusively(Native Method)
        at java.io.File.createNewFile(File.java:1012)
        at com.aliyun.emr.rss.service.deploy.worker.LocalStorageManager.createWriter(LocalStorageManager.scala:441)
        at com.aliyun.emr.rss.service.deploy.worker.LocalStorageManager.createWriter(LocalStorageManager.scala:415)
        at com.aliyun.emr.rss.service.deploy.worker.Worker.$anonfun$handleReserveSlots$3(Worker.scala:344)
        at scala.runtime.java8.JFunction1$mcZI$sp.apply(JFunction1$mcZI$sp.java:23)
        at scala.collection.immutable.Range.foreach(Range.scala:158)
        at com.aliyun.emr.rss.service.deploy.worker.Worker.com$aliyun$emr$rss$service$deploy$worker$Worker$$handleReserveSlots(Worker.scala:341)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$1(Worker.scala:290)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at com.aliyun.emr.rss.common.metrics.source.AbstractSource.sample(AbstractSource.scala:119)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anonfun$receiveAndReply$1.applyOrElse(Worker.scala:285)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.$anonfun$process$1(Inbox.scala:110)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.safelyCall(Inbox.scala:214)
        at com.aliyun.emr.rss.common.rpc.netty.Inbox.process(Inbox.scala:107)
        at com.aliyun.emr.rss.common.rpc.netty.Dispatcher$MessageLoop.run(Dispatcher.scala:222)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
22/09/09 13:01:50,533 ERROR [dispatcher-event-loop-19] LocalDeviceMonitor: Receive report exception, /mnt/ssd/1/rss-worker/shuffle_data, java.io.IOException: java.io.IOException: Permission denied
22/09/09 13:01:50,533 ERROR [dispatcher-event-loop-19] DiskFlusher: DiskFlusher@719449906-/mnt/ssd/1/rss-worker/shuffle_data is notified Device sdb Error ReadOrWriteFailure! Stop Flusher.
22/09/09 13:01:50,533 ERROR [dispatcher-event-loop-19] LocalStorageManager: LocalStorageManager is notified DeviceError,dirs ListBuffer(/mnt/ssd/1/rss-worker/shuffle_data), updated numSlots: 80000
22/09/09 13:01:50,533 ERROR [DiskFlusher@719449906-/mnt/ssd/1/rss-worker/shuffle_data-2] DiskFlusher: com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$2@5e80a7b7 thread terminated.
java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$1.run(LocalStorageManager.scala:82)
22/09/09 13:01:50,533 ERROR [DiskFlusher@719449906-/mnt/ssd/1/rss-worker/shuffle_data-3] DiskFlusher: com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$2@2e610d18 thread terminated.
java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$1.run(LocalStorageManager.scala:82)
22/09/09 13:01:50,533 ERROR [DiskFlusher@719449906-/mnt/ssd/1/rss-worker/shuffle_data-0] DiskFlusher: com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$2@39cbe27 thread terminated.
java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$1.run(LocalStorageManager.scala:82)
22/09/09 13:01:50,533 ERROR [DiskFlusher@719449906-/mnt/ssd/1/rss-worker/shuffle_data-1] DiskFlusher: com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$2@4692c991 thread terminated.
java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.reportInterruptAfterWait(AbstractQueuedSynchronizer.java:2014)
        at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(AbstractQueuedSynchronizer.java:2048)
        at java.util.concurrent.LinkedBlockingQueue.take(LinkedBlockingQueue.java:442)
        at com.aliyun.emr.rss.service.deploy.worker.DiskFlusher$$anon$1.run(LocalStorageManager.scala:82)
22/09/09 13:01:50,537 INFO [Cleaner] Worker: Cleaned up expired shuffle application_1661230219745_3926926_1-0
22/09/09 13:01:50,537 INFO [Cleaner] LocalStorageManager: Cleanup expired shuffle application_1661230219745_3926926_1-0.
22/09/09 13:01:50,537 ERROR [dispatcher-event-loop-19] LocalStorageManager: Create Writer failed, report to DeviceMonitor
java.io.IOException: Permission denied
        at java.io.UnixFileSystem.createFileExclusively(Native Method)
        at java.io.File.createNewFile(File.java:1012)
        at com.aliyun.emr.rss.service.deploy.worker.LocalStorageManager.createWriter(LocalStorageManager.scala:441)
        at com.aliyun.emr.rss.service.deploy.worker.LocalStorageManager.createWriter(LocalStorageManager.scala:415)
        at com.aliyun.emr.rss.service.deploy.worker.Worker.$anonfun$handleReserveSlots$3(Worker.scala:344)
        at scala.runtime.java8.JFunction1$mcZI$sp.apply(JFunction1$mcZI$sp.java:23)
        at scala.collection.immutable.Range.foreach(Range.scala:158)
        at com.aliyun.emr.rss.service.deploy.worker.Worker.com$aliyun$emr$rss$service$deploy$worker$Worker$$handleReserveSlots(Worker.scala:341)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anonfun$receiveAndReply$1.$anonfun$applyOrElse$1(Worker.scala:290)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at com.aliyun.emr.rss.common.metrics.source.AbstractSource.sample(AbstractSource.scala:119)
        at com.aliyun.emr.rss.service.deploy.worker.Worker$$anonfun$receiveAndReply$1.applyOrElse(Worker.scala:285)
```

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
