### PR TITLE
[ISSUE-578][FEATURE] Add unit test for codec

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -55,6 +55,10 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -57,6 +57,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Compressor.java
@@ -24,15 +24,12 @@ import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.xxhash.XXHashFactory;
 
 public class RssLz4Compressor extends RssLz4Trait implements Compressor {
-  private final int compressionLevel;
   private final LZ4Compressor compressor;
   private final Checksum checksum;
   private byte[] compressedBuffer;
   private int compressedTotalSize;
 
   public RssLz4Compressor(int blockSize) {
-    int level = 32 - Integer.numberOfLeadingZeros(blockSize - 1) - COMPRESSION_LEVEL_BASE;
-    this.compressionLevel = Math.max(0, level);
     this.compressor = LZ4Factory.fastestInstance().fastCompressor();
     checksum = XXHashFactory.fastestInstance().newStreamingHash32(DEFAULT_SEED).asChecksum();
     initCompressBuffer(blockSize);
@@ -65,7 +62,7 @@ public class RssLz4Compressor extends RssLz4Trait implements Compressor {
       compressMethod = COMPRESSION_METHOD_LZ4;
     }
 
-    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+    compressedBuffer[MAGIC_LENGTH] = (byte) compressMethod;
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);
     writeIntLE(check, compressedBuffer, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Decompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Decompressor.java
@@ -42,8 +42,7 @@ public class RssLz4Decompressor extends RssLz4Trait implements Decompressor {
 
   @Override
   public int decompress(byte[] src, byte[] dst, int dstOff) {
-    int token = src[MAGIC_LENGTH] & 0xFF;
-    int compressionMethod = token & 0xF0;
+    int compressionMethod = src[MAGIC_LENGTH] & 0xFF;
     int compressedLen = readIntLE(src, MAGIC_LENGTH + 1);
     int originalLen = readIntLE(src, MAGIC_LENGTH + 5);
     int check = readIntLE(src, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Trait.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssLz4Trait.java
@@ -23,7 +23,7 @@ public abstract class RssLz4Trait {
 
   public static final int HEADER_LENGTH =
       MAGIC_LENGTH // magic bytes
-          + 1 // token
+          + 1 // compress method
           + 4 // compressed length
           + 4 // decompressed length
           + 4; // checksum

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdCompressor.java
@@ -69,7 +69,7 @@ public class RssZstdCompressor extends RssZstdTrait implements Compressor {
       compressMethod = COMPRESSION_METHOD_ZSTD;
     }
 
-    compressedBuffer[MAGIC_LENGTH] = (byte) (compressMethod | compressionLevel);
+    compressedBuffer[MAGIC_LENGTH] = (byte) compressMethod;
     writeIntLE(compressedLength, compressedBuffer, MAGIC_LENGTH + 1);
     writeIntLE(length, compressedBuffer, MAGIC_LENGTH + 5);
     writeIntLE(check, compressedBuffer, MAGIC_LENGTH + 9);

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdDecompressor.java
@@ -39,10 +39,9 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
 
   @Override
   public int decompress(byte[] src, byte[] dst, int dstOff) {
-    int token = src[MAGIC_LENGTH] & 0xFF;
-    int compressionMethod = token & 0xF0;
+    int compressionMethod = src[MAGIC_LENGTH] & 0xFF;
     int compressedLen = readIntLE(src, MAGIC_LENGTH + 1);
-    int originalLen = getOriginalLen(src);
+    int originalLen = readIntLE(src, MAGIC_LENGTH + 5);
     int check = readIntLE(src, MAGIC_LENGTH + 9);
 
     switch (compressionMethod) {
@@ -59,6 +58,10 @@ public class RssZstdDecompressor extends RssZstdTrait implements Decompressor {
               "Original length corrupted! expected: {}, actual: {}.", originalLen, originalLen2);
           return -1;
         }
+        break;
+      default:
+        logger.error("Unknown compression method whose decimal number is {} .", compressionMethod);
+        return -1;
     }
 
     checksum.reset();

--- a/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdTrait.java
+++ b/client/src/main/java/com/aliyun/emr/rss/client/compress/RssZstdTrait.java
@@ -23,7 +23,7 @@ public abstract class RssZstdTrait {
 
   public static final int HEADER_LENGTH =
       MAGIC_LENGTH // magic bytes
-          + 1 // token
+          + 1 // compress method
           + 4 // compressed length
           + 4 // decompressed length
           + 4; // checksum

--- a/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
+++ b/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
@@ -42,6 +42,7 @@ public class CodecSuite {
 
     Assert.assertNotEquals(-1, decompressLength);
     Assert.assertEquals(oriLength, decompressLength);
+    Assert.assertArrayEquals(data, dst);
   }
 
   @Test
@@ -61,6 +62,7 @@ public class CodecSuite {
 
       Assert.assertNotEquals(-1, decompressLength);
       Assert.assertEquals(oriLength, decompressLength);
+      Assert.assertArrayEquals(data, dst);
     }
   }
 }

--- a/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
+++ b/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.aliyun.emr.rss.client.compress;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.aliyun.emr.rss.common.RssConf;
+
+public class CodecSuite {
+
+  @Test
+  public void testLz4Codec() {
+    int blockSize = RssConf.pushDataBufferSize(new RssConf());
+    RssLz4Compressor rssLz4Compressor = new RssLz4Compressor(blockSize);
+    byte[] data = RandomStringUtils.random(1024).getBytes(StandardCharsets.UTF_8);
+    int oriLength = data.length;
+    rssLz4Compressor.compress(data, 0, oriLength);
+
+    RssLz4Decompressor rssLz4Decompressor = new RssLz4Decompressor();
+    byte[] dst = new byte[oriLength];
+    int decompressLength =
+        rssLz4Decompressor.decompress(rssLz4Compressor.getCompressedBuffer(), dst, 0);
+
+    Assert.assertNotEquals(-1, decompressLength);
+    Assert.assertEquals(oriLength, decompressLength);
+  }
+
+  @Test
+  public void testZstdCodec() {
+    for (int level = 0; level <= 22; level++) {
+      System.out.println("level is " + level);
+      int blockSize = RssConf.pushDataBufferSize(new RssConf());
+      RssZstdCompressor rssZstdCompressor = new RssZstdCompressor(blockSize, level);
+      byte[] data = RandomStringUtils.random(1024).getBytes(StandardCharsets.UTF_8);
+      int oriLength = data.length;
+      rssZstdCompressor.compress(data, 0, oriLength);
+
+      RssZstdDecompressor rssZstdDecompressor = new RssZstdDecompressor();
+      byte[] dst = new byte[oriLength];
+      int decompressLength =
+          rssZstdDecompressor.decompress(rssZstdCompressor.getCompressedBuffer(), dst, 0);
+
+      Assert.assertNotEquals(-1, decompressLength);
+      Assert.assertEquals(oriLength, decompressLength);
+    }
+  }
+}

--- a/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
+++ b/client/src/test/java/com/aliyun/emr/rss/client/compress/CodecSuite.java
@@ -46,7 +46,7 @@ public class CodecSuite {
 
   @Test
   public void testZstdCodec() {
-    for (int level = 0; level <= 22; level++) {
+    for (int level = -5; level <= 22; level++) {
       System.out.println("level is " + level);
       int blockSize = RssConf.pushDataBufferSize(new RssConf());
       RssZstdCompressor rssZstdCompressor = new RssZstdCompressor(blockSize, level);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add independent unit test for lz4 and zstd codec

### Why are the changes needed?
To prevent #551 by unit test rather than finding the problem when running real jobs on prod cluster.

### What are the items that need reviewer attention?
Need to merge #577 first, then cherrypick it into current branch to fix the workflow which can't pass when zstd level is negative.

### Related issues.
#578 

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
