### PR TITLE
Correct binary tarball extension name in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,4 +29,4 @@ RUN set -ex && \
     rm -rf /var/cache/apt/* && \
     mkdir -p /opt/
 
-ADD rss-${rss_version}-bin-release.tar.gz /opt/
+ADD rss-${rss_version}-bin-release.tgz /opt/


### PR DESCRIPTION
### What changes were proposed in this pull request?

Use `xxx.tgz` in Dockerfile

### Why are the changes needed?

`dev/make-distribution.sh` produces `xxx.tgz`, but `docker/Dockerfile` uses `xxx.tar.gz`

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
