### PR TITLE
DeviceMonitor init failed because of NPE.

### DIFF
--- a/common/src/main/scala/com/aliyun/emr/rss/common/meta/DeviceInfo.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/meta/DeviceInfo.scala
@@ -151,7 +151,7 @@ object DeviceInfo {
     val deviceNameToDeviceInfo = new util.HashMap[String, DeviceInfo]()
     val mountPointToDeviceInfo = new util.HashMap[String, DeviceInfo]()
 
-    val dfResult = runCommand("df -h").trim
+    val dfResult = runCommand("df -ah").trim
     logger.info(s"df result $dfResult")
     // (/dev/vdb, /mnt/disk1)
     val fsMounts = dfResult

--- a/server-worker/src/test/scala/com/aliyun/emr/rss/service/deploy/worker/storage/DeviceMonitorSuite.scala
+++ b/server-worker/src/test/scala/com/aliyun/emr/rss/service/deploy/worker/storage/DeviceMonitorSuite.scala
@@ -35,7 +35,7 @@ import com.aliyun.emr.rss.common.protocol.StorageInfo
 import com.aliyun.emr.rss.common.util.Utils
 
 class DeviceMonitorSuite extends AnyFunSuite {
-  val dfCmd = "df -h"
+  val dfCmd = "df -ah"
   val dfOut =
     """
       |Filesystem      Size  Used Avail  Use% Mounted on


### PR DESCRIPTION
# [BUG]/[FEATURE] DeviceMonitor init failed because of NPE.

### What changes were proposed in this pull request?


### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If multiple directories are mounted to the same disk,the mounting information of the working directory may not be found .As a result,the npe occurs,causing DeviceMonitor  initialization failure.

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
