### PR TITLE
[ISSUE-612][Refactor] Refactor error log of PartitionFileSorter

### DIFF
--- a/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/storage/PartitionFilesSorter.java
+++ b/server-worker/src/main/java/com/aliyun/emr/rss/service/deploy/worker/storage/PartitionFilesSorter.java
@@ -183,10 +183,10 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
             sorting.add(fileId);
             shuffleSortTaskDeque.put(fileSorter);
           } catch (InterruptedException e) {
-            logger.info("scheduler thread is interrupted means worker is shutting down.");
+            logger.info("Scheduler thread is interrupted means worker is shutting down.");
             return null;
           } catch (IOException e) {
-            logger.error("File sorter access hdfs failed.", e);
+            logger.error("FileSorter access hdfs failed.", e);
             return null;
           }
         }
@@ -198,15 +198,16 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
           try {
             Thread.sleep(50);
             if (System.currentTimeMillis() - sortStartTime > sortTimeout) {
-              logger.error("sort file {} timeout", fileId);
+              logger.error("Sorting file {} timeout after {}ms", fileId, sortTimeout);
               return null;
             }
           } catch (InterruptedException e) {
-            logger.error("sort scheduler thread is interrupted means worker is shutting down.", e);
+            logger.error("Sort scheduler thread is interrupted means worker is shutting down.", e);
             return null;
           }
         } else {
-          logger.error("file {} sort failed", fileId);
+          logger.debug(
+              "Sorting shuffle file for {} {} failed,", shuffleKey, fileInfo.getFilePath());
           return null;
         }
       }
@@ -459,7 +460,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
             cachedIndexMaps.computeIfAbsent(shuffleKey, v -> new ConcurrentHashMap<>());
         cacheMap.put(fileId, indexMap);
       } catch (Exception e) {
-        logger.error("Read sorted shuffle file error, detail : ", e);
+        logger.error("Read sorted shuffle file index " + indexFilePath + " error, detail: ", e);
         return null;
       } finally {
         IOUtils.closeQuietly(indexStream, null);
@@ -573,7 +574,8 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         deleteOriginFiles();
         logger.debug("sort complete for {} {}", shuffleKey, originFilePath);
       } catch (Exception e) {
-        logger.error("sort shuffle file {} error", originFilePath, e);
+        logger.error(
+            "Sorting shuffle file for " + fileId + " " + originFilePath + " failed, detail: ", e);
       } finally {
         Set<String> sorting = sortingShuffleFiles.get(shuffleKey);
         synchronized (sorting) {
@@ -624,7 +626,7 @@ public class PartitionFilesSorter extends ShuffleRecoverHelper {
         deleteSuccess = new File(originFilePath).delete();
       }
       if (!deleteSuccess) {
-        logger.warn("clean origin file failed, origin file is : {}", originFilePath);
+        logger.warn("Clean origin file failed, origin file is : {}", originFilePath);
       }
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?

Refactor the error log to use the format of print error trace since it's not convenient when use grep to check the error log
```
22/09/16 11:35:58,923 ERROR [worker-file-sorter-execute-360] PartitionFilesSorter: sort shuffle file 724-0-0 error
22/09/16 11:35:58,943 ERROR [fetch-server-11-23] PartitionFilesSorter: file application_1661230813707_5515788_1-31-724-0-0 sort failed

```

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.
https://github.com/alibaba/RemoteShuffleService/issues/612

### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
