### PR TITLE
Make shuffle read consume less off-heap memory when CoalescePartition occurs

### DIFF
--- a/client-spark/shuffle-manager-2/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
+++ b/client-spark/shuffle-manager-2/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
@@ -59,7 +59,7 @@ class RssShuffleReader[K, C](
         readMetrics.incFetchWaitTime(time)
     }
 
-    val recordIter = (startPartition until endPartition).map(partitionId => {
+    val recordIter = (startPartition until endPartition).iterator.map(partitionId => {
       if (handle.numMaps > 0) {
         val start = System.currentTimeMillis()
         val inputStream = essShuffleClient.readPartition(
@@ -77,7 +77,7 @@ class RssShuffleReader[K, C](
       } else {
         RssInputStream.empty()
       }
-    }).toIterator.flatMap(
+    }).flatMap(
       serializerInstance.deserializeStream(_).asKeyValueIterator)
 
     val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](

--- a/client-spark/shuffle-manager-3/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
+++ b/client-spark/shuffle-manager-3/src/main/scala/org/apache/spark/shuffle/rss/RssShuffleReader.scala
@@ -60,7 +60,7 @@ class RssShuffleReader[K, C](
         metrics.incFetchWaitTime(time)
     }
 
-    val recordIter = (startPartition until endPartition).map(partitionId => {
+    val recordIter = (startPartition until endPartition).iterator.map(partitionId => {
       if (handle.numMappers > 0) {
         val start = System.currentTimeMillis()
         val inputStream = rssShuffleClient.readPartition(
@@ -79,7 +79,7 @@ class RssShuffleReader[K, C](
       } else {
         RssInputStream.empty()
       }
-    }).toIterator.flatMap(
+    }).flatMap(
       serializerInstance.deserializeStream(_).asKeyValueIterator)
 
     val metricIter = CompletionIterator[(Any, Any), Iterator[(Any, Any)]](


### PR DESCRIPTION
# Make shuffle read consume less off-heap memory when CoalescePartition occurs

### What changes were proposed in this pull request?

Create RssInputStreamImpl partition by partition to prevent multiple RssInputStreamImpl instances from being created at one time, resulting in overrun of off-heap memory usage

### Why are the changes needed?


### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @waitinfuture 

/assign @main-reviewer
