### PR TITLE
Drop control message Scala wrapper V2 - CheckForWorkerTimeOut

### DIFF
--- a/common/src/main/proto/TransportMessages.proto
+++ b/common/src/main/proto/TransportMessages.proto
@@ -356,6 +356,9 @@ message PbThreadDumpResponse {
   string threadDump = 1;
 }
 
+message PbCheckForWorkerTimeout {
+}
+
 message PbWorkerLost {
   string host = 1;
   int32 rpcPort = 2;

--- a/common/src/main/scala/com/aliyun/emr/rss/common/util/Utils.scala
+++ b/common/src/main/scala/com/aliyun/emr/rss/common/util/Utils.scala
@@ -751,7 +751,7 @@ object Utils extends Logging {
   }
 
   def toTransportMessage(message: Any): Any = {
-    message match {
+    ControlMessages.mapToTransportMessage(message) match {
       case transportMessage: Message =>
         transportMessage.toTransportMessage
       case _ =>

--- a/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
+++ b/server-master/src/main/scala/com/aliyun/emr/rss/service/deploy/master/Master.scala
@@ -32,9 +32,9 @@ import com.aliyun.emr.rss.common.internal.Logging
 import com.aliyun.emr.rss.common.meta.{DiskInfo, WorkerInfo}
 import com.aliyun.emr.rss.common.metrics.MetricsSystem
 import com.aliyun.emr.rss.common.metrics.source.{JVMCPUSource, JVMSource, RPCSource}
-import com.aliyun.emr.rss.common.protocol.{PartitionLocation, RpcNameConstants}
+import com.aliyun.emr.rss.common.protocol.{PartitionLocation, PbCheckForWorkerTimeout, RpcNameConstants}
+import com.aliyun.emr.rss.common.protocol.message.{ControlMessages, StatusCode}
 import com.aliyun.emr.rss.common.protocol.message.ControlMessages._
-import com.aliyun.emr.rss.common.protocol.message.StatusCode
 import com.aliyun.emr.rss.common.rpc._
 import com.aliyun.emr.rss.common.util.{ThreadUtils, Utils}
 import com.aliyun.emr.rss.server.common.{HttpService, Service}
@@ -145,7 +145,7 @@ private[deploy] class Master(
     checkForWorkerTimeOutTask = forwardMessageThread.scheduleAtFixedRate(
       new Runnable {
         override def run(): Unit = Utils.tryLogNonFatalError {
-          self.send(CheckForWorkerTimeOut)
+          self.send(ControlMessages.pbCheckForWorkerTimeout)
         }
       },
       0,
@@ -184,7 +184,7 @@ private[deploy] class Master(
     if (HAHelper.checkShouldProcess(context, statusSystem)) f
 
   override def receive: PartialFunction[Any, Unit] = {
-    case CheckForWorkerTimeOut =>
+    case _: PbCheckForWorkerTimeout =>
       executeWithLeaderChecker(null, timeoutDeadWorkers())
     case CheckForApplicationTimeOut =>
       executeWithLeaderChecker(null, timeoutDeadApplications())


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is an alternative of #674, in this approach, I keep the transparent transformation between TransportMessage and PbXXX, and we always use PbXXX the application layer.

If this approach is accepted, #674, #675, #676 should be reverted.

### Why are the changes needed?

<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

### What are the items that need reviewer attention?


### Related issues.


### Related pull requests.


### How was this patch tested?


/cc @related-reviewer

/assign @main-reviewer
