### PR TITLE
[ISSUE-691][BUG] SortBasedPusher pass 0 to allocateArray when calling growPointerArrayIfNecessary

### DIFF
--- a/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/ShuffleInMemorySorter.java
+++ b/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/ShuffleInMemorySorter.java
@@ -62,7 +62,6 @@ public class ShuffleInMemorySorter {
     return initialSize;
   }
 
-
   public void freeMemory() {
     if (consumer != null) {
       if (array != null) {
@@ -80,9 +79,7 @@ public class ShuffleInMemorySorter {
     pos = 0;
   }
 
-  /**
-   * @return the number of records that have been inserted into this sorter.
-   */
+  /** @return the number of records that have been inserted into this sorter. */
   public int numRecords() {
     return pos / 2;
   }
@@ -95,11 +92,11 @@ public class ShuffleInMemorySorter {
         // checkstyle.on: RegexpSinglelineJava
       }
       Platform.copyMemory(
-              array.getBaseObject(),
-              array.getBaseOffset(),
-              newArray.getBaseObject(),
-              newArray.getBaseOffset(),
-              pos * 8L);
+          array.getBaseObject(),
+          array.getBaseOffset(),
+          newArray.getBaseObject(),
+          newArray.getBaseOffset(),
+          pos * 8L);
       consumer.freeArray(array);
     }
     array = newArray;

--- a/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/ShuffleInMemorySorter.java
+++ b/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/ShuffleInMemorySorter.java
@@ -81,7 +81,7 @@ public class ShuffleInMemorySorter {
 
   /** @return the number of records that have been inserted into this sorter. */
   public int numRecords() {
-    return pos / 2;
+    return pos;
   }
 
   public void expandPointerArray(LongArray newArray) {

--- a/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/SortBasedPusher.java
+++ b/client-spark/shuffle-manager-common/src/main/java/org/apache/spark/shuffle/rss/SortBasedPusher.java
@@ -271,8 +271,8 @@ public class SortBasedPusher extends MemoryConsumer {
    * additional memory from the memory manager and spill if the requested memory can not be
    * obtained.
    *
-   * @param required the required space in the data page, in bytes, including space for storing
-   *                 the record size.
+   * @param required the required space in the data page, in bytes, including space for storing the
+   *     record size.
    */
   private void acquireNewPageIfNecessary(int required) {
     if (currentPage == null
@@ -287,8 +287,8 @@ public class SortBasedPusher extends MemoryConsumer {
    * Allocates more memory in order to insert an additional record. This will request additional
    * memory from the memory manager and spill if the requested memory can not be obtained.
    *
-   * @param required the required space in the data page, in bytes, including space for storing
-   *                 the record size.
+   * @param required the required space in the data page, in bytes, including space for storing the
+   *     record size.
    */
   private void allocateMemoryForRecordIfNecessary(int required) throws IOException {
     // Step 1:


### PR DESCRIPTION
### What changes were proposed in this pull request?
Backport from [SPARK-32901](https://jira.shopee.io/browse/SPARK-32901)

### Why are the changes needed?
To fix the bug caused by allocateArray(0)

### What are the items that need reviewer attention?


### Related issues.
#691 

### Related pull requests.


### How was this patch tested?


/cc @AngersZhuuuu 

/assign @main-reviewer
